### PR TITLE
Ensure that the framework driver unloads the test domain after discovery...

### DIFF
--- a/src/NUnitTestAdapter/NUnit/NUnit3FrameworkDriver.cs
+++ b/src/NUnitTestAdapter/NUnit/NUnit3FrameworkDriver.cs
@@ -83,6 +83,13 @@ namespace NUnit.Engine.Drivers
             return handler.Result;
         }
 
+        public void Unload()
+        {
+            // TODO: This should probably be done externally or the driver modified to create the domain
+            if (_testDomain != null)
+                AppDomain.Unload(_testDomain);
+        }
+
         public int CountTestCases(TestFilter filter)
         {
             CallbackHandler handler = new CallbackHandler();

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -49,13 +49,15 @@ namespace NUnit.VisualStudio.TestAdapter
                 if (IsNUnit3TestAssembly(sourceAssembly))
                 {
                     TestConverter testConverter = null;
+                    NUnit3FrameworkDriver frameworkDriver = null;
+
                     try
                     {
-                        var driver = GetDriver(sourceAssembly);
-                        XmlNode loadResult = XmlHelper.CreateXmlNode(driver.Load());
+                        frameworkDriver = GetDriver(sourceAssembly);
+                        XmlNode loadResult = XmlHelper.CreateXmlNode(frameworkDriver.Load());
                         if (loadResult.GetAttribute("runstate") == "Runnable")
                         {
-                            XmlNode topNode = XmlHelper.CreateXmlNode(driver.Explore(TestFilter.Empty));
+                            XmlNode topNode = XmlHelper.CreateXmlNode(frameworkDriver.Explore(TestFilter.Empty));
 
                             testConverter = new TestConverter(TestLog, sourceAssembly);
                             int cases = ProcessTestCases(topNode, discoverySink,testConverter);
@@ -90,6 +92,9 @@ namespace NUnit.VisualStudio.TestAdapter
                     {
                         if (testConverter != null)
                             testConverter.Dispose();
+
+                        if (frameworkDriver != null)
+                            frameworkDriver.Unload();
                     }
                 }
             }


### PR DESCRIPTION
... and execution. Fixes #8 

This fixes _one_ of the things that holds onto the test assembly and prevents building. There's still another issue to fix, related to the IsNUnit3TestAssembly method in NUnit3TestDiscoverer. I tested by replacing the body of that method with 'return true' and found that i could discover tests, execute them and rebuild. I'm not combining both fixes here because... well, I don't actually have a fix for that other one yet. :-)