### PR TITLE
Fix #10 - Test Discoverer reflection holds open file

### DIFF
--- a/src/NUnitTestAdapter/NUnit/NUnit3FrameworkDriver.cs
+++ b/src/NUnitTestAdapter/NUnit/NUnit3FrameworkDriver.cs
@@ -40,7 +40,7 @@ namespace NUnit.Engine.Drivers
     {
         private const string NUNIT_FRAMEWORK = "nunit.framework";
 
-        private static readonly string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
+        public static readonly string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
         private static readonly string LOAD_ACTION = CONTROLLER_TYPE + "+LoadTestsAction";
         private static readonly string EXPLORE_ACTION = CONTROLLER_TYPE + "+ExploreTestsAction";
         private static readonly string COUNT_ACTION = CONTROLLER_TYPE + "+CountTestsAction";
@@ -144,12 +144,7 @@ namespace NUnit.Engine.Drivers
         private object CreateObject(string typeName, params object[] args)
         {
             return _testDomain.CreateInstanceAndUnwrap(
-                _frameworkAssemblyName, typeName, false, 0,
-#if !NET_4_0
-                null, args, null, null, null );
-#else
-                null, args, null, null );
-#endif
+                _frameworkAssemblyName, typeName, false, 0, null, args, null, null, null );
         }
 
         #endregion

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -229,7 +229,6 @@ namespace NUnit.VisualStudio.TestAdapter
             var thisAssembly = Assembly.GetExecutingAssembly();
             setup.ApplicationBase = Path.GetDirectoryName(thisAssembly.ManifestModule.FullyQualifiedName);
 
-            //var evidence = AppDomain.CurrentDomain.Evidence;
             this.asyncMethodHelperDomain = AppDomain.CreateDomain("AsyncMethodHelper", null, setup);
 
             try


### PR DESCRIPTION
I decided to stop trying to test the assembly before creating a driver. Instead, I examine how the driver fails and just give warnings for NUnit 2.x or non-NUnit assemblies. That's actually how we do it in the original adapter in fact.
