### PR TITLE
Changed name of adapter dll to end with the patterns *.TestAdapter.dll, ...

### DIFF
--- a/nuget/NUnit3VisualStudioTestAdapter.nuspec
+++ b/nuget/NUnit3VisualStudioTestAdapter.nuspec
@@ -22,7 +22,7 @@ The package works with Visual Studio 2012 from RTM, and with Update 1 and higher
         <tags>test visualstudio testadapter nunit nunit3</tags>
     </metadata>
     <files>
-        <file src="${package.working.dir}\NUnit3TestAdapter.dll" target="lib\NUnit3TestAdapter.dll" />
+        <file src="${package.working.dir}\NUnit3.TestAdapter.dll" target="lib\NUnit3.TestAdapter.dll" />
         <file src="${project.nuget.dir}\install.ps1" target="tools\install.ps1" />
     </files>
 </package>

--- a/nunit3-vs-adapter.build
+++ b/nunit3-vs-adapter.build
@@ -55,7 +55,7 @@
     <!-- a reference to each binary we want to include.      -->
 		<copy todir="${package.working.dir}">
 			<fileset basedir="${install.release.dir}">
-				<include name="NUnit3TestAdapter.dll"/>
+				<include name="NUnit3.TestAdapter.dll"/>
 			</fileset>
 		</copy>
 

--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NUnit.VisualStudio.TestAdapter</RootNamespace>
-    <AssemblyName>NUnit3TestAdapter</AssemblyName>
+    <AssemblyName>NUnit3.TestAdapter</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>

--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -33,6 +33,6 @@
   </Identifier>
   <References />
   <Content>
-    <CustomExtension Type="UnitTestExtension">NUnit3TestAdapter.dll</CustomExtension>
+    <CustomExtension Type="UnitTestExtension">NUnit3.TestAdapter.dll</CustomExtension>
   </Content>
 </Vsix>

--- a/src/NUnitTestAdapterTests/ProjectTests.cs
+++ b/src/NUnitTestAdapterTests/ProjectTests.cs
@@ -15,16 +15,24 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [Test]
         public void ThatTheTestAdapterUsesFrameWork35()
         {
-            var dir = Directory.GetCurrentDirectory();
-            var assembly = Assembly.LoadFrom(dir+"/NUnit3TestAdapter.dll");
+            var dir = TestContext.CurrentContext.TestDirectory;
+            var assembly = Assembly.LoadFrom(dir+"/NUnit3.TestAdapter.dll");
             var version = assembly.ImageRuntimeVersion;
             Assert.That(version,Is.EqualTo("v2.0.50727"),"The NUnitTestAdapter project must be set to target .net framework 3.5");
         }
 
         [Test]
+        public void ThatTheTestAdapterEndsWithTestAdapterDll()
+        {
+            var dir = TestContext.CurrentContext.TestDirectory;
+            bool found = File.Exists(dir + "/NUnit3.TestAdapter.dll");
+            Assert.That(found,Is.True,string.Format(@"Did not find 'NUnit3.TestAdapter.dll' in {0}. Ensure the Testadapter ends with '.TestAdapter.dll'",dir));
+        }
+
+        [Test]
         public void ThatNoMSTestDLLIsCopiedToOutput()
         {
-            var dir = Directory.GetCurrentDirectory();
+            var dir = TestContext.CurrentContext.TestDirectory;
             var filesNotToExist = Directory.EnumerateFiles(dir, "Microsoft", SearchOption.TopDirectoryOnly);
             Assert.IsTrue(!filesNotToExist.Any(),"The reference of NUnitTestAdapter - Microsoft.VisualStudio.TestPlatform.ObjectModel must be set Copy Local to false");
         }
@@ -32,8 +40,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [Test]
         public void ThatTheReferenceToMicrosoftTestObjectModelPointsToVS2012Version()
         {
-            var dir = Directory.GetCurrentDirectory();
-            var assembly = Assembly.LoadFrom(dir + "/NUnit3TestAdapter.dll");
+            var dir = TestContext.CurrentContext.TestDirectory;
+            var assembly = Assembly.LoadFrom(dir + "/NUnit3.TestAdapter.dll");
             var refNames = assembly.GetReferencedAssemblies().Where(ass=>ass.Name=="Microsoft.VisualStudio.TestPlatform.ObjectModel").ToList();
             Assert.IsTrue(refNames != null && refNames.Count() == 1, "No reference to Microsoft.VisualStudio.TestPlatform.ObjectModel found");
             Assert.IsTrue(refNames[0].Version.Major == 11, "Microsoft.VisualStudio.TestPlatform.ObjectModel must point to the 2012 version (11)");


### PR DESCRIPTION
...required for VS to locate it.  #13