### PR TITLE
Update to NUnit 3.0 beta 2; fixes #20

### DIFF
--- a/demo/NUnitTestDemo/NUnit3TestDemo.csproj
+++ b/demo/NUnitTestDemo/NUnit3TestDemo.csproj
@@ -36,9 +36,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.0.5562.31842, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=3.0.5607.22015, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.3.0.0-beta-1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.3.0.0-beta-2\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/demo/NUnitTestDemo/packages.config
+++ b/demo/NUnitTestDemo/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.0.0-beta-1" targetFramework="net45" />
+  <package id="NUnit" version="3.0.0-beta-2" targetFramework="net45" />
 </packages>

--- a/src/NUnitTestAdapter/AssemblyRunner.cs
+++ b/src/NUnitTestAdapter/AssemblyRunner.cs
@@ -126,10 +126,6 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 _logger.SendErrorMessage("Exception thrown executing tests in " + _assemblyName, ex);
             }
-            finally
-            {
-                _frameworkDriver.Unload();
-            }
         }
 
         public void CancelRun()
@@ -146,7 +142,7 @@ namespace NUnit.VisualStudio.TestAdapter
         private bool TryLoadAssembly(bool shadowCopy)
         {
             _frameworkDriver = GetDriver(_assemblyName, shadowCopy);
-            XmlNode loadResult = XmlHelper.CreateXmlNode(_frameworkDriver.Load());
+            XmlNode loadResult = XmlHelper.CreateXmlNode(_frameworkDriver.Load(_assemblyName, new Dictionary<string, object>()));
             if (loadResult.GetAttribute("runstate") != "Runnable")
                 return false;
 
@@ -173,7 +169,7 @@ namespace NUnit.VisualStudio.TestAdapter
             var settings = new Dictionary<string, object>();
             settings["ShadowCopyFiles"] = shadowCopy;
 
-            var driver = new NUnit3FrameworkDriver(domain, sourceAssembly, settings);
+            var driver = new NUnit3FrameworkDriver(domain);
             return driver;
         }
 

--- a/src/NUnitTestAdapter/NUnit/IFrameworkDriver.cs
+++ b/src/NUnitTestAdapter/NUnit/IFrameworkDriver.cs
@@ -35,10 +35,16 @@ namespace NUnit.Engine.Extensibility
     public interface IFrameworkDriver
     {
         /// <summary>
+        /// Gets and sets the unique identifier for this driver,
+        /// used to ensure that test ids are unique across drivers.
+        /// </summary>
+        string ID { get; set; }
+
+        /// <summary>
         /// Loads the tests in an assembly.
         /// </summary>
         /// <returns>An Xml string representing the loaded test</returns>
-        string Load();
+        string Load(string testAssemblyPath, IDictionary<string, object> settings);
 
         /// <summary>
         /// Count the test cases that would be executed.

--- a/src/NUnitTestAdapter/NUnit/NUnit3FrameworkDriver.cs
+++ b/src/NUnitTestAdapter/NUnit/NUnit3FrameworkDriver.cs
@@ -22,12 +22,8 @@
 // ***********************************************************************
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Collections.Generic;
-using System.Web.UI;
-using System.Xml;
-//using NUnit.Engine.Internal;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Drivers
@@ -39,8 +35,9 @@ namespace NUnit.Engine.Drivers
     public class NUnit3FrameworkDriver : IFrameworkDriver
     {
         private const string NUNIT_FRAMEWORK = "nunit.framework";
+        private const string LOAD_MESSAGE = "Method called without calling Load first";
 
-        public static readonly string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
+        private static readonly string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
         private static readonly string LOAD_ACTION = CONTROLLER_TYPE + "+LoadTestsAction";
         private static readonly string EXPLORE_ACTION = CONTROLLER_TYPE + "+ExploreTestsAction";
         private static readonly string COUNT_ACTION = CONTROLLER_TYPE + "+CountTestsAction";
@@ -51,30 +48,33 @@ namespace NUnit.Engine.Drivers
 
         AppDomain _testDomain;
         string _testAssemblyPath;
-        string _frameworkAssemblyName;
 
         object _frameworkController;
 
-        public NUnit3FrameworkDriver(AppDomain testDomain, string testAssemblyPath, IDictionary<string, object> settings)
-            : this(testDomain, NUNIT_FRAMEWORK, testAssemblyPath, settings) { }
-
-        public NUnit3FrameworkDriver(AppDomain testDomain, string frameworkAssemblyName, string testAssemblyPath, IDictionary<string, object> settings)
+        /// <summary>
+        /// Construct an NUnit3FrameworkDriver
+        /// </summary>
+        /// <param name="testDomain">The AppDomain in which to create the FrameworkController</param>
+        public NUnit3FrameworkDriver(AppDomain testDomain)
         {
-            if (!File.Exists(testAssemblyPath))
-                throw new ArgumentException("Framework driver constructor called with a file name that doesn't exist.", "testAssemblyPath");
-
             _testDomain = testDomain;
-            _testAssemblyPath = testAssemblyPath;
-            _frameworkAssemblyName = frameworkAssemblyName;
-            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, (System.Collections.IDictionary)settings);
         }
+
+        public string ID { get; set; }
 
         /// <summary>
         /// Loads the tests in an assembly.
         /// </summary>
         /// <returns>An Xml string representing the loaded test</returns>
-        public string Load()
+        public string Load(string testAssemblyPath, IDictionary<string, object> settings)
         {
+            if (!File.Exists(testAssemblyPath))
+                throw new ArgumentException("Framework driver constructor called with a file name that doesn't exist.", "testAssemblyPath");
+
+            var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
+            _testAssemblyPath = testAssemblyPath;
+            _frameworkController = CreateObject(CONTROLLER_TYPE, testAssemblyPath, idPrefix, (System.Collections.IDictionary)settings);
+
             CallbackHandler handler = new CallbackHandler();
 
             //log.Info("Loading {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
@@ -83,15 +83,10 @@ namespace NUnit.Engine.Drivers
             return handler.Result;
         }
 
-        public void Unload()
-        {
-            // TODO: This should probably be done externally or the driver modified to create the domain
-            if (_testDomain != null)
-                AppDomain.Unload(_testDomain);
-        }
-
         public int CountTestCases(TestFilter filter)
         {
+            CheckLoadWasCalled();
+
             CallbackHandler handler = new CallbackHandler();
 
             CreateObject(COUNT_ACTION, _frameworkController, filter.Text, handler);
@@ -107,6 +102,8 @@ namespace NUnit.Engine.Drivers
         /// <returns>An Xml string representing the result</returns>
         public string Run(ITestEventListener listener, TestFilter filter)
         {
+            CheckLoadWasCalled();
+
             CallbackHandler handler = new CallbackHandler(listener);
 
             //log.Info("Running {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
@@ -131,6 +128,8 @@ namespace NUnit.Engine.Drivers
         /// <returns>An Xml string representing the tests</returns>
         public string Explore(TestFilter filter)
         {
+            CheckLoadWasCalled();
+
             CallbackHandler handler = new CallbackHandler();
 
             //log.Info("Exploring {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
@@ -141,10 +140,21 @@ namespace NUnit.Engine.Drivers
 
         #region Helper Methods
 
+        private void CheckLoadWasCalled()
+        {
+            if (_frameworkController == null)
+                throw new InvalidOperationException(LOAD_MESSAGE);
+        }
+
         private object CreateObject(string typeName, params object[] args)
         {
             return _testDomain.CreateInstanceAndUnwrap(
-                _frameworkAssemblyName, typeName, false, 0, null, args, null, null, null );
+                NUNIT_FRAMEWORK, typeName, false, 0,
+#if !NET_4_0
+                null, args, null, null, null );
+#else
+                null, args, null, null );
+#endif
         }
 
         #endregion

--- a/src/NUnitTestAdapter/NUnit/NUnit3FrameworkDriver.cs
+++ b/src/NUnitTestAdapter/NUnit/NUnit3FrameworkDriver.cs
@@ -47,7 +47,7 @@ namespace NUnit.Engine.Drivers
         //static ILogger log = InternalTrace.GetLogger("NUnitFrameworkDriver");
 
         AppDomain _testDomain;
-        string _testAssemblyPath;
+        //string _testAssemblyPath;
 
         object _frameworkController;
 
@@ -150,11 +150,7 @@ namespace NUnit.Engine.Drivers
         {
             return _testDomain.CreateInstanceAndUnwrap(
                 NUNIT_FRAMEWORK, typeName, false, 0,
-#if !NET_4_0
                 null, args, null, null, null );
-#else
-                null, args, null, null );
-#endif
         }
 
         #endregion

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -52,7 +52,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 try
                 {
                     frameworkDriver = GetDriver(sourceAssembly);
-                    XmlNode loadResult = XmlHelper.CreateXmlNode(frameworkDriver.Load());
+                    XmlNode loadResult = XmlHelper.CreateXmlNode(frameworkDriver.Load(sourceAssembly, new Dictionary<string, object>()));
                     if (loadResult.GetAttribute("runstate") == "Runnable")
                     {
                         XmlNode topNode = XmlHelper.CreateXmlNode(frameworkDriver.Explore(TestFilter.Empty));
@@ -84,7 +84,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 }
                 catch (TypeLoadException ex)
                 {
-                    if (ex.TypeName == NUnit3FrameworkDriver.CONTROLLER_TYPE)
+                    if (ex.TypeName == "NUnit.Framework.Api.FrameworkController")
                         TestLog.SendWarningMessage("   Skipping NUnit 2.x test assembly");
                     else
                         TestLog.SendErrorMessage("Exception thrown discovering tests in " + sourceAssembly, ex);
@@ -97,9 +97,6 @@ namespace NUnit.VisualStudio.TestAdapter
                 {
                     if (testConverter != null)
                         testConverter.Dispose();
-
-                    if (frameworkDriver != null)
-                        frameworkDriver.Unload();
                 }
             }
 
@@ -119,7 +116,7 @@ namespace NUnit.VisualStudio.TestAdapter
             var settings = new Dictionary<string, object>();
             settings["ShadowCopyFiles"] = ShadowCopy;
 
-            var driver = new NUnit3FrameworkDriver(domain, sourceAssembly, settings);
+            var driver = new NUnit3FrameworkDriver(domain);
             return driver;
         }
 

--- a/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
@@ -46,9 +46,9 @@
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.1.1309.1617\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.0.5562.31842, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=3.0.5607.22015, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NUnit.3.0.0-beta-1\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.3.0.0-beta-2\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/NUnitTestAdapterTests/app.config
+++ b/src/NUnitTestAdapterTests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.5562.31842" newVersion="3.0.5562.31842" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.5607.22015" newVersion="3.0.5607.22015" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NUnitTestAdapterTests/packages.config
+++ b/src/NUnitTestAdapterTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.1.1309.1617" targetFramework="net45" />
-  <package id="NUnit" version="3.0.0-beta-1" targetFramework="net45" />
+  <package id="NUnit" version="3.0.0-beta-2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Upgrades the tests to use NUnit 3.0.0-beta-2 and modifies the framework driver and other files to work with the new interface. These changes are mostly temporary since #19 will replace all the files in the NUnit subdirectory with use of the core engine.