### PR TITLE
Runs and discovers tests in a separate domain

### DIFF
--- a/src/NUnitTestAdapter/EngineWrapper.cs
+++ b/src/NUnitTestAdapter/EngineWrapper.cs
@@ -1,0 +1,140 @@
+﻿// ****************************************************************
+// Copyright (c) 2011-2015 NUnit Software. All rights reserved.
+// ****************************************************************
+
+using NUnit.Engine;
+using System;
+using System.Xml;
+
+namespace NUnit.VisualStudio.TestAdapter
+{
+    [Serializable]
+    internal class EngineWrapper : MarshalByRefObject, ITestEngine
+    {
+        [NonSerialized]
+        private ITestEngine _engine = new TestEngine();
+
+        public InternalTraceLevel InternalTraceLevel
+        {
+            get { return _engine.InternalTraceLevel; }
+            set { _engine.InternalTraceLevel = value; }
+        }
+
+        public IServiceLocator Services
+        {
+            get { return _engine.Services; }
+        }
+
+        public string WorkDirectory
+        {
+            get { return _engine.WorkDirectory; }
+            set { _engine.WorkDirectory = value; }
+        }
+
+        public void Dispose()
+        {
+            _engine.Dispose();
+        }
+
+        public ITestRunner GetRunner(TestPackage package)
+        {
+            ITestRunner runner = _engine.GetRunner(package);
+            return new RunnerWrapper(runner);
+        }
+
+        public void Initialize()
+        {
+            _engine.Initialize();
+        }
+    }
+
+    [Serializable]
+    public class RunnerWrapper : MarshalByRefObject, ITestRunner
+    {
+        [NonSerialized]
+        private ITestRunner _runner;
+
+        public RunnerWrapper(ITestRunner runner)
+        {
+            _runner = runner;
+        }
+
+        public bool IsTestRunning
+        {
+            get { return _runner.IsTestRunning; }
+        }
+
+        public int CountTestCases(TestFilter filter)
+        {
+            return _runner.CountTestCases(filter);
+        }
+
+        public void Dispose()
+        {
+            _runner.Dispose();
+        }
+
+        public XmlNode Explore(TestFilter filter)
+        {
+            throw new NotImplementedException("Not used by the test adapter");
+        }
+
+        internal string ExploreInternal(TestFilter filter)
+        {
+            return _runner.Explore(filter).OuterXml;
+        }
+
+        public XmlNode Load()
+        {
+            throw new NotImplementedException("Not used by the test adapter");
+        }
+
+        internal string LoadInternal()
+        {
+            return _runner.Load().OuterXml;
+        }
+
+        public XmlNode Reload()
+        {
+            throw new NotImplementedException("Not used by the test adapter");
+        }
+
+        public XmlNode Run(ITestEventListener listener, TestFilter filter)
+        {
+            throw new NotImplementedException("Not used by the test adapter");
+        }
+
+        internal string RunInternal(ITestEventListener listener, TestFilter filter)
+        {
+            return _runner.Run(listener, filter).OuterXml;
+        }
+
+        public ITestRun RunAsync(ITestEventListener listener, TestFilter filter)
+        {
+            // The returned ITestRun won't be serializable, so don't use
+            throw new NotImplementedException("Not used by the test adapter");
+        }
+
+        public void StopRun(bool force)
+        {
+            _runner.StopRun(force);
+        }
+        
+        public void Unload()
+        {
+            _runner.Unload();
+        }
+    }
+
+    internal static class XmlNodeExtensions
+    {
+        public static XmlNode ToXml(this string xml)
+        {
+            var doc = new XmlDocument();
+            var fragment = doc.CreateDocumentFragment();
+            fragment.InnerXml = xml;
+            doc.AppendChild(fragment);
+            return doc.FirstChild;
+        }
+    }
+}

--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="nunit.core.engine, Version=3.0.5610.33198, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
@@ -64,6 +64,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EngineWrapper.cs" />
     <Compile Include="NUnitEventListener.cs" />
     <Compile Include="Internal\AsyncMethodHelper.cs" />
     <Compile Include="Internal\Stackframe.cs" />

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -31,7 +31,7 @@ namespace NUnit.VisualStudio.TestAdapter
         private TfsTestFilter _tfsFilter;
 
         // Fields related to the currently executing assembly
-        private ITestRunner _testRunner;
+        private RunnerWrapper _testRunner;
         private TestFilter _nunitFilter = TestFilter.Empty;
 
         #region ITestExecutor Implementation
@@ -80,6 +80,7 @@ namespace NUnit.VisualStudio.TestAdapter
             finally
             {
                 Info("executing tests", "finished");
+                Unload();
             }
 
         }
@@ -113,7 +114,7 @@ namespace NUnit.VisualStudio.TestAdapter
             }
 
             Info("executing tests", "finished");
-
+            Unload();
         }
 
         void ITestExecutor.Cancel()
@@ -157,7 +158,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
             try
             {
-                var loadResult = _testRunner.Explore(TestFilter.Empty);
+                var loadResult = _testRunner.ExploreInternal(TestFilter.Empty).ToXml();
 
                 if (loadResult.Name == "test-run")
                     loadResult = loadResult.FirstChild;
@@ -189,7 +190,7 @@ namespace NUnit.VisualStudio.TestAdapter
                         {
                             try
                             {
-                                _testRunner.Run(listener, _nunitFilter);
+                                _testRunner.RunInternal(listener, _nunitFilter);
                             }
                             catch (NullReferenceException)
                             {
@@ -216,6 +217,8 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 TestLog.SendErrorMessage("Exception thrown executing tests in " + assemblyName, ex);
             }
+            _testRunner.Dispose();
+            Unload();
         }
 
         private static TestFilter MakeTestFilter(IEnumerable<TestCase> testCases)

--- a/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="mock-assembly">
       <HintPath>..\mock-assembly\bin\Release\mock-assembly.dll</HintPath>


### PR DESCRIPTION
So that test assemblie do not remain locked. Fixes #29.

Terje, this is working except for a small bug. I am out of time and have to leave in a few minutes, so I was hoping you could take a look.

This is based on your work, I just changed the wrappers around a bit to only return serializable objects. Sorry, I changed the reference paths to VS 2015 because that is the only machine I had with me.

I can discover and run all tests or individual tests and the test assemblies do not get locked. This works with or without the keep test engine running setting.

The only issue is there seems to be a discovery pass after the test run, so the tests go grey after they run. I am not sure what I did there. If you can figure that out, then I think we are ready to go. We will want to increase the version number, but I can do that and prepare a release later tonight or in the morning.