### PR TITLE
Issue 29 :  Locking dll's, code cleanup

### DIFF
--- a/src/NUnitTestAdapter/EngineWrapper.cs
+++ b/src/NUnitTestAdapter/EngineWrapper.cs
@@ -4,15 +4,13 @@
 
 using NUnit.Engine;
 using System;
-using System.Xml;
 
 namespace NUnit.VisualStudio.TestAdapter
 {
-   // [Serializable]
-    internal class EngineWrapper : MarshalByRefObject, ITestEngine
+    public class EngineWrapper : MarshalByRefObject 
     {
-       // [NonSerialized]
-        private ITestEngine _engine = new TestEngine();
+      
+        private readonly ITestEngine _engine = new TestEngine();
 
         public InternalTraceLevel InternalTraceLevel
         {
@@ -36,7 +34,7 @@ namespace NUnit.VisualStudio.TestAdapter
             _engine.Dispose();
         }
 
-        public ITestRunner GetRunner(TestPackage package)
+        public RunnerWrapper GetRunner(TestPackage package)
         {
             ITestRunner runner = _engine.GetRunner(package);
             return new RunnerWrapper(runner);
@@ -45,96 +43,6 @@ namespace NUnit.VisualStudio.TestAdapter
         public void Initialize()
         {
             _engine.Initialize();
-        }
-    }
-
-   // [Serializable]
-    public class RunnerWrapper : MarshalByRefObject, ITestRunner
-    {
-       // [NonSerialized]
-        private ITestRunner _runner;
-
-        public RunnerWrapper(ITestRunner runner)
-        {
-            _runner = runner;
-        }
-
-        public bool IsTestRunning
-        {
-            get { return _runner.IsTestRunning; }
-        }
-
-        public int CountTestCases(TestFilter filter)
-        {
-            return _runner.CountTestCases(filter);
-        }
-
-        public void Dispose()
-        {
-            _runner.Dispose();
-        }
-
-        public XmlNode Explore(TestFilter filter)
-        {
-            throw new NotImplementedException("Not used by the test adapter");
-        }
-
-        internal string ExploreInternal(TestFilter filter)
-        {
-            return _runner.Explore(filter).OuterXml;
-        }
-
-        public XmlNode Load()
-        {
-            throw new NotImplementedException("Not used by the test adapter");
-        }
-
-        internal string LoadInternal()
-        {
-            return _runner.Load().OuterXml;
-        }
-
-        public XmlNode Reload()
-        {
-            throw new NotImplementedException("Not used by the test adapter");
-        }
-
-        public XmlNode Run(ITestEventListener listener, TestFilter filter)
-        {
-            throw new NotImplementedException("Not used by the test adapter");
-        }
-
-        internal string RunInternal(ITestEventListener listener, TestFilter filter)
-        {
-            return _runner.Run(listener, filter).OuterXml;
-        }
-
-        public ITestRun RunAsync(ITestEventListener listener, TestFilter filter)
-        {
-            // The returned ITestRun won't be serializable, so don't use
-            throw new NotImplementedException("Not used by the test adapter");
-        }
-
-        public void StopRun(bool force)
-        {
-            _runner.StopRun(force);
-        }
-        
-        public void Unload()
-        {
-            _runner.Unload();
-        }
-    }
-
-    internal static class XmlNodeExtensions
-    {
-        public static XmlNode ToXml(this string xml)
-        {
-            var doc = new XmlDocument();
-            var fragment = doc.CreateDocumentFragment();
-            fragment.InnerXml = xml;
-            doc.AppendChild(fragment);
-            return doc.FirstChild;
         }
     }
 }

--- a/src/NUnitTestAdapter/EngineWrapper.cs
+++ b/src/NUnitTestAdapter/EngineWrapper.cs
@@ -8,10 +8,10 @@ using System.Xml;
 
 namespace NUnit.VisualStudio.TestAdapter
 {
-    [Serializable]
+   // [Serializable]
     internal class EngineWrapper : MarshalByRefObject, ITestEngine
     {
-        [NonSerialized]
+       // [NonSerialized]
         private ITestEngine _engine = new TestEngine();
 
         public InternalTraceLevel InternalTraceLevel
@@ -48,10 +48,10 @@ namespace NUnit.VisualStudio.TestAdapter
         }
     }
 
-    [Serializable]
+   // [Serializable]
     public class RunnerWrapper : MarshalByRefObject, ITestRunner
     {
-        [NonSerialized]
+       // [NonSerialized]
         private ITestRunner _runner;
 
         public RunnerWrapper(ITestRunner runner)

--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="nunit.core.engine, Version=3.0.5610.33198, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
@@ -73,6 +73,7 @@
     <Compile Include="NUnitTestAdapter.cs" />
     <Compile Include="NUnit3TestDiscoverer.cs" />
     <Compile Include="NUnit3TestExecutor.cs" />
+    <Compile Include="RunnerWrapper.cs" />
     <Compile Include="TestConverter.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="nunit.core.engine, Version=3.0.5610.33198, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="nunit.core.engine, Version=3.0.5610.33198, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -28,7 +28,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         #region Properties
 
-        protected ITestEngine TestEngine { get; private set; }
+        protected EngineWrapper TestEngine { get; private set; }
 
         // Our logger used to display messages
         protected TestLogger TestLog { get; private set; }
@@ -116,7 +116,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         private AppDomain _engineDomain;
 
-        protected ITestEngine CreateTestEngine()
+        protected internal EngineWrapper CreateTestEngine()
         {
             var setup = new AppDomainSetup
             {
@@ -125,7 +125,7 @@ namespace NUnit.VisualStudio.TestAdapter
             var evidence = AppDomain.CurrentDomain.Evidence;
             _engineDomain = AppDomain.CreateDomain("EngineDomain", evidence, setup);
             var engine = _engineDomain.CreateInstanceAndUnwrap(typeof(EngineWrapper).Assembly.FullName, typeof(EngineWrapper).FullName);
-            return engine as ITestEngine;
+            return engine as EngineWrapper;
         }
 
         protected void Unload()

--- a/src/NUnitTestAdapter/RunnerWrapper.cs
+++ b/src/NUnitTestAdapter/RunnerWrapper.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Xml;
+using NUnit.Engine;
+
+namespace NUnit.VisualStudio.TestAdapter
+{
+    public class RunnerWrapper : MarshalByRefObject // , ITestRunner
+    {
+      
+        private readonly ITestRunner _runner;
+
+        public RunnerWrapper(ITestRunner runner)
+        {
+            _runner = runner;
+        }
+
+        public bool IsTestRunning
+        {
+            get { return _runner.IsTestRunning; }
+        }
+
+        public int CountTestCases(TestFilter filter)
+        {
+            return _runner.CountTestCases(filter);
+        }
+
+        public void Dispose()
+        {
+            _runner.Dispose();
+        }
+
+       
+
+        internal string ExploreInternal(TestFilter filter)
+        {
+            return _runner.Explore(filter).OuterXml;
+        }
+
+        
+        internal string LoadInternal()
+        {
+            return _runner.Load().OuterXml;
+        }
+
+       
+
+        internal string RunInternal(ITestEventListener listener, TestFilter filter)
+        {
+            return _runner.Run(listener, filter).OuterXml;
+        }
+
+        
+
+        public void StopRun(bool force)
+        {
+            _runner.StopRun(force);
+        }
+        
+        public void Unload()
+        {
+            _runner.Unload();
+        }
+    }
+}

--- a/src/NUnitTestAdapter/RunnerWrapper.cs
+++ b/src/NUnitTestAdapter/RunnerWrapper.cs
@@ -4,7 +4,7 @@ using NUnit.Engine;
 
 namespace NUnit.VisualStudio.TestAdapter
 {
-    public class RunnerWrapper : MarshalByRefObject // , ITestRunner
+    public class RunnerWrapper : MarshalByRefObject 
     {
       
         private readonly ITestRunner _runner;

--- a/src/NUnitTestAdapter/XmlHelper.cs
+++ b/src/NUnitTestAdapter/XmlHelper.cs
@@ -52,6 +52,15 @@ namespace NUnit.VisualStudio.TestAdapter
             return doc.FirstChild;
         }
 
+        public static XmlNode ToXml(this string xml)
+        {
+            var doc = new XmlDocument();
+            var fragment = doc.CreateDocumentFragment();
+            fragment.InnerXml = xml;
+            doc.AppendChild(fragment);
+            return doc.FirstChild;
+        }
+
         /// <summary>
         /// Adds an attribute with a specified name and value to an existing XmlNode.
         /// </summary>
@@ -121,7 +130,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
             return attr == null
                 ? defaultValue
-                : int.Parse(attr.Value, System.Globalization.CultureInfo.InvariantCulture);
+                : Int32.Parse(attr.Value, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -137,7 +146,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
             return attr == null
                 ? defaultValue
-                : double.Parse(attr.Value, System.Globalization.CultureInfo.InvariantCulture);
+                : Double.Parse(attr.Value, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+      <HintPath>$(MSBuildProgramFiles32)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
     </Reference>
     <Reference Include="mock-assembly">
       <HintPath>..\mock-assembly\bin\Release\mock-assembly.dll</HintPath>


### PR DESCRIPTION
I have cleaned up the code, removed the Serialization attributes, they were not needed.  Further, I split the two wrappers into separate files, and I moved the XmlNode extension method to the XmlHelper class where we have more of the same.  
I also removed the interfaces from the wrappers, and the corresponding "Not implemented" methods, as these classes don't really implement those interfaces any more.
I have no locking anymore.
I have no duplicate test discoveries, and no grey tests. 

However, I have issues running the tests that uses the mockassembly.  I am running out of time now, and I guess this might just be a local issue, because the external test on a test projects works just fine. 

The only thing then left before releasing this, is to update the version numbers.  If this PR is ok, and the tests run fine by you Rob,. then either of us can release this as a ctp3  I can do this tomorrow morning (9 hours from now).  