### PR TITLE
Removed extra Unload which caused nullref exceptions when testing mul…

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -61,7 +61,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     if (!(enableShutdown && !runContext.KeepAlive))  // Otherwise causes exception when run as commandline, illegal to enableshutdown when Keepalive is false, might be only VS2012
                         frameworkHandle.EnableShutdownAfterTestRun = enableShutdown;
                 }
-                
+
                 foreach (var source in sources)
                 {
                     var assemblyName = source;
@@ -100,7 +100,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
             var enableShutdown = (UseVsKeepEngineRunning) ? !runContext.KeepAlive : true;
             frameworkHandle.EnableShutdownAfterTestRun = enableShutdown;
-            Debug("executing tests", "EnableShutdown set to " +enableShutdown);
+            Debug("executing tests", "EnableShutdown set to " + enableShutdown);
 
             var assemblyGroups = tests.GroupBy(tc => tc.Source);
             foreach (var assemblyGroup in assemblyGroups)
@@ -218,7 +218,6 @@ namespace NUnit.VisualStudio.TestAdapter
                 TestLog.SendErrorMessage("Exception thrown executing tests in " + assemblyName, ex);
             }
             _testRunner.Dispose();
-            Unload();
         }
 
         private static TestFilter MakeTestFilter(IEnumerable<TestCase> testCases)


### PR DESCRIPTION
The Unload statement removes the TestEngine, and this happens after the first assembly has been tested. 

No locking issue seen after this removal.  There is an Unload at the outer level which unloads the TestEngine when all tests are done.