### PR TITLE
Set NumberOfTestWorkers to zero when running under the debugger. Fixes #36

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -26,7 +26,8 @@ namespace NUnit.VisualStudio.TestAdapter
         public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger messageLogger, ITestCaseDiscoverySink discoverySink)
         {
 #if LAUNCHDEBUGGER
-            Debugger.Launch();
+            if (!Debugger.IsAttached)
+                Debugger.Launch();
 #endif
             Initialize(messageLogger);
 
@@ -127,7 +128,8 @@ namespace NUnit.VisualStudio.TestAdapter
                 try
                 {
 #if LAUNCHDEBUGGER
-                    Debugger.Launch();
+                    if (!Debugger.IsAttached)
+                        Debugger.Launch();
 #endif
                     TestCase testCase = testConverter.ConvertTestCase(testNode);
                     discoverySink.SendTestCase(testCase);

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -47,7 +47,8 @@ namespace NUnit.VisualStudio.TestAdapter
         public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
 #if LAUNCHDEBUGGER
-            Debugger.Launch();
+            if (!Debugger.IsAttached)
+                Debugger.Launch();
 #endif
             Initialize(frameworkHandle);
 
@@ -94,7 +95,8 @@ namespace NUnit.VisualStudio.TestAdapter
         public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
         {
 #if LAUNCHDEBUGGER
-            Debugger.Launch();
+            if (!Debugger.IsAttached)
+                Debugger.Launch();
 #endif
             Initialize(frameworkHandle);
 
@@ -106,7 +108,10 @@ namespace NUnit.VisualStudio.TestAdapter
             foreach (var assemblyGroup in assemblyGroups)
             {
                 var assemblyName = assemblyGroup.Key;
-                TestLog.SendInformationalMessage("Running selected tests in " + assemblyName);
+                if (Debugger.IsAttached)
+                    TestLog.SendInformationalMessage("Debugging selected tests in " + assemblyName);
+                else
+                    TestLog.SendInformationalMessage("Running selected tests in " + assemblyName);
 
                 _nunitFilter = MakeTestFilter(assemblyGroup);
 
@@ -152,7 +157,8 @@ namespace NUnit.VisualStudio.TestAdapter
         private void RunAssembly(string assemblyName, IFrameworkHandle frameworkHandle)
         {
 #if LAUNCHDEBUGGER
-            System.Diagnostics.Debugger.Launch();
+            if (!Debugger.IsAttached)
+                Debugger.Launch();
 #endif
             _testRunner = GetRunnerFor(assemblyName);
 

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -3,6 +3,7 @@
 // ****************************************************************
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Remoting.Channels;
@@ -88,8 +89,18 @@ namespace NUnit.VisualStudio.TestAdapter
         protected RunnerWrapper GetRunnerFor(string assemblyName)
         {
             var package = new TestPackage(assemblyName);
+
             if (_shadowCopy)
+            {
                 package.Settings["ShadowCopyFiles"] = "true";
+                TestLog.SendDebugMessage("    Setting ShadowCopyFiles to true");
+            }
+
+            if (Debugger.IsAttached)
+            {
+                package.Settings["NumberOfTestWorkers"] = 0;
+                TestLog.SendDebugMessage("    Setting NumberOfTestWorkers to zero");
+            }
 
             return TestEngine.GetRunner(package) as RunnerWrapper;
         }


### PR DESCRIPTION
Basically, if the debugger is attached, we won't run in parallel. This will require temporary code changes when we want to debug parallel execution itself, but makes it simpler for the user to debug tests, which is the point.