### PR TITLE
Create pseudo-results for ignored and skipped test cases for which NU…

### DIFF
--- a/demo/NUnitTestDemo/ExpectedOutcomeAttributes.cs
+++ b/demo/NUnitTestDemo/ExpectedOutcomeAttributes.cs
@@ -23,6 +23,11 @@ namespace NUnitTestDemo
         public ExpectIgnoreAttribute() : base("Expect", "Ignore") { }
     }
 
+    public class ExpectSkipAttribute : PropertyAttribute
+    {
+        public ExpectSkipAttribute() : base("Expect", "Skipped") { }
+    }
+
     public class ExpectErrorAttribute : PropertyAttribute
     {
         public ExpectErrorAttribute() : base("Expect", "Error") { }

--- a/demo/NUnitTestDemo/NUnit3TestDemo.csproj
+++ b/demo/NUnitTestDemo/NUnit3TestDemo.csproj
@@ -48,7 +48,7 @@
   <ItemGroup>
     <Compile Include="AsyncTests.cs" />
     <Compile Include="ConfigFileTests.cs" />
-    <Compile Include="ExpetedOutcomeAttributes.cs" />
+    <Compile Include="ExpectedOutcomeAttributes.cs" />
     <Compile Include="GenericTests.cs" />
     <Compile Include="TextOutputTests.cs" />
     <Compile Include="ParameterizedTests.cs" />

--- a/demo/NUnitTestDemo/ParameterizedTests.cs
+++ b/demo/NUnitTestDemo/ParameterizedTests.cs
@@ -61,6 +61,17 @@ namespace NUnitTestDemo
             Assert.Ignore("Ignoring this test case");
         }
 
+        [TestCase(31, 11, ExcludePlatform="NET"), ExpectSkip]
+        public void TestCaseIsSkipped_Property(int a, int b)
+        {
+        }
+
+        [Platform(Exclude = "NET"), ExpectSkip]
+        [TestCase(31, 11)]
+        public void TestCaseIsSkipped_Attribute(int a, int b)
+        {
+        }
+
         [TestCase(31, 11), ExpectError]
         public void TestCaseThrowsException(int a, int b)
         {

--- a/demo/NUnitTestDemo/SimpleTests.cs
+++ b/demo/NUnitTestDemo/SimpleTests.cs
@@ -50,6 +50,12 @@ namespace NUnitTestDemo
             Assert.Ignore("Ignoring this test deliberately");
         }
 
+        // Since we only run under .NET, test is always excluded
+        [Test, ExpectSkip, Platform("Exclude=\"NET\"")]
+        public void TestIsSkipped_Platform()
+        {
+        }
+
         [Test, ExpectError]
         public void TestThrowsException()
         {

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -2,7 +2,7 @@
 // Copyright (c) 2011-2015 NUnit Software. All rights reserved.
 // ****************************************************************
 
-//#define LAUNCHDEBUGGER
+#define LAUNCHDEBUGGER
 
 using System;
 using System.Collections.Generic;

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -2,7 +2,7 @@
 // Copyright (c) 2011-2015 NUnit Software. All rights reserved.
 // ****************************************************************
 
-#define LAUNCHDEBUGGER
+//#define LAUNCHDEBUGGER
 
 using System;
 using System.Collections.Generic;

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -167,6 +167,8 @@ namespace NUnit.VisualStudio.TestAdapter
                 {
                     TestLog.SendInformationalMessage(string.Format("Loading tests from {0}", assemblyName));
 
+                    var nunitTestCases = loadResult.SelectNodes("//test-case");
+
                     using (var testConverter = new TestConverter(TestLog, assemblyName))
                     {
                         var loadedTestCases = new List<TestCase>();
@@ -174,7 +176,7 @@ namespace NUnit.VisualStudio.TestAdapter
                         // As a side effect of calling TestConverter.ConvertTestCase, 
                         // the converter's cache of all test cases is populated as well. 
                         // All future calls to convert a test case may now use the cache.
-                        foreach (XmlNode testNode in loadResult.SelectNodes("//test-case"))
+                        foreach (XmlNode testNode in nunitTestCases)
                             loadedTestCases.Add(testConverter.ConvertTestCase(testNode));
 
                         // If we have a TFS Filter, convert it to an nunit filter
@@ -198,6 +200,8 @@ namespace NUnit.VisualStudio.TestAdapter
                                 TestLog.SendDebugMessage("Nullref caught");
                             }
                         }
+
+                        new NonEventTestProcessor(frameworkHandle, testConverter).ProcessTests(loadResult);
                     }
                 }
                 else
@@ -230,6 +234,64 @@ namespace NUnit.VisualStudio.TestAdapter
             testFilter.Append("</tests></filter>");
 
             return new TestFilter(testFilter.ToString());
+        }
+
+        #endregion
+
+        #region Nested NonEventTestProcessor Class
+
+        // This class implements an adhoc fix necessitated by the fact that NUnit 
+        // does not send events for tests that are not executed either due to the
+        // presence of an attribute that changes the runstate or to an error that
+        // makes the test NonRunnable. Consequently, no result is ever reported
+        // to VS for such tests by the NUnitEventListener.
+        //
+        // To make up for this, we go through the tests and create pseudo-results 
+        // for each one that is identified as not producing an event.
+        //
+        // TODO: Remove this after NUnit is modified to send events for all test cases
+        class NonEventTestProcessor
+        {
+            private IFrameworkHandle _frameworkHandle;
+            private TestConverter _testConverter;
+
+            public NonEventTestProcessor(IFrameworkHandle frameworkHandle, TestConverter testConverter)
+            {
+                _frameworkHandle = frameworkHandle;
+                _testConverter = testConverter;
+            }
+
+            public void ProcessTests(XmlNode node)
+            {
+                string name = node.Name;
+                string runstate = node.GetAttribute("runstate");
+
+                if (name == "test-suite" || name == "test-run")
+                {
+                    if (runstate == "Ignored" || runstate=="Skipped")
+                        ReportTestCases(node, TestOutcome.Skipped);
+                    else // Keep descending
+                        foreach (XmlNode childNode in node.ChildNodes)
+                            ProcessTests(childNode);
+                }
+            }
+
+            private void ReportTestCases(XmlNode node, TestOutcome outcome)
+            {
+                foreach (XmlNode childNode in node.ChildNodes)
+                {
+                    if (childNode.Name == "test-case")
+                    {
+                        var result = new TestResult(_testConverter.ConvertTestCase(childNode));
+                        result.Outcome = outcome;
+                        _frameworkHandle.RecordResult(result);
+                    }
+                    else if (childNode.Name == "test-suite" || childNode.Name == "test-run")
+                    {
+                        ReportTestCases(childNode, outcome);
+                    }
+                }
+            }
         }
 
         #endregion

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -105,16 +105,19 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public void SuiteFinished(XmlNode resultNode)
         {
-            if (resultNode.GetAttribute("result") == "Failed")
+            var result = resultNode.GetAttribute("result");
+            var label = resultNode.GetAttribute("label");
+            var site = resultNode.GetAttribute("site");
+
+            if (result == "Failed")
             {
-                var site = resultNode.GetAttribute("site");
                 if (site == "SetUp" || site == "TearDown")
                 {
                     testLog.SendMessage(
                         TestMessageLevel.Error,
                         string.Format("{0} failed for test fixture {1}", site, resultNode.GetAttribute("fullname")));
 
-                    var messageNode = resultNode.SelectSingleNode("failure/messge");
+                    var messageNode = resultNode.SelectSingleNode("failure/message");
                     if (messageNode != null)
                         testLog.SendMessage(TestMessageLevel.Error, messageNode.InnerText);
 


### PR DESCRIPTION
…nit doesn't send events. Fixes #26 

As a temporary measure, we go through all the loaded NUnit tests. Any suite that is skipped or ignored will not send events for it's contained tests, so we recursively descend under that suite, create results for each case and send them to Visual Studio.

This should probably be changed in NUnit and we should then remove the workaround to avoid sending duplicate results.