### PR TITLE
Release 3.0 ctp 4

### DIFF
--- a/demo/NUnitTestDemo/NUnit3TestDemo.csproj
+++ b/demo/NUnitTestDemo/NUnit3TestDemo.csproj
@@ -36,9 +36,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.0.5610.33194, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=3.0.5674.19278, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.3.0.0-beta-2\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.3.0.0-beta-3\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/demo/NUnitTestDemo/packages.config
+++ b/demo/NUnitTestDemo/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.0.0-beta-2" targetFramework="net45" />
+  <package id="NUnit" version="3.0.0-beta-3" targetFramework="net45" />
 </packages>

--- a/src/NUnitTestAdapter/packages.config
+++ b/src/NUnitTestAdapter/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Core.Engine" version="3.0.0-beta-3" targetFramework="net35" />
+  <package id="NUnit.Core.Engine" version="3.0.0-beta-2" targetFramework="net35" />
 </packages>

--- a/src/NUnitTestAdapterInstall/packages.config
+++ b/src/NUnitTestAdapterInstall/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Core.Engine" version="3.0.0-beta-3" targetFramework="net45" />
+  <package id="NUnit.Core.Engine" version="3.0.0-beta-2" targetFramework="net45" />
 </packages>

--- a/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
@@ -47,9 +47,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NUnit.Core.Engine.3.0.0-beta-2\lib\nunit.core.engine.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.0.5610.33194, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=3.0.5674.19278, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NUnit.3.0.0-beta-2\lib\net45\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.3.0.0-beta-3\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -92,15 +92,15 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             const FakeFrameworkHandle.EventType eventType = FakeFrameworkHandle.EventType.RecordResult;
             Assert.That(
                 testLog.Events.FindAll(e => e.EventType == eventType).Count,
-                Is.EqualTo(MockAssembly.ResultCount - TestsUnderBadOrIgnoredFixtures));
+                Is.EqualTo(MockAssembly.ResultCount - BadFixture.Tests));
         }
 
-        readonly TestCaseData[] outcomes =
+        static readonly TestCaseData[] outcomes =
         {
             // NOTE: One inconclusive test is reported as None
             new TestCaseData(TestOutcome.Passed).Returns(MockAssembly.Success),
             new TestCaseData(TestOutcome.Failed).Returns(MockAssembly.ErrorsAndFailures - BadFixture.Tests),
-            new TestCaseData(TestOutcome.Skipped).Returns(MockAssembly.Ignored - IgnoredFixture.Tests),
+            new TestCaseData(TestOutcome.Skipped).Returns(MockAssembly.Ignored),
             new TestCaseData(TestOutcome.None).Returns(1),
             new TestCaseData(TestOutcome.NotFound).Returns(0)
         };

--- a/src/NUnitTestAdapterTests/packages.config
+++ b/src/NUnitTestAdapterTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.0.0-beta-2" targetFramework="net45" />
+  <package id="NUnit" version="3.0.0-beta-3" targetFramework="net45" />
   <package id="NUnit.Core.Engine" version="3.0.0-beta-2" targetFramework="net45" />
 </packages>

--- a/src/mock-assembly/mock-assembly.csproj
+++ b/src/mock-assembly/mock-assembly.csproj
@@ -79,9 +79,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.0.5610.33194, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>packages\NUnit.3.0.0-beta-2\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.0.5674.19278, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>packages\NUnit.3.0.0-beta-3\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/src/mock-assembly/packages.config
+++ b/src/mock-assembly/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.0.0-beta-2" targetFramework="net45" />
+  <package id="NUnit" version="3.0.0-beta-3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is the ctp-4 release of the adapter. Since we'd like to get it out, I only plan on leaving it here for review for a few hours before merging.

I found that mock-assembly and NUnit3TestDemo were actually using the beta 2 framework. So were the tests for the adapter itself. Of the three adapter projects, two were using the beta 3 core engine and one - the tests - was using the beta 2 engine.

After I straightened things out and made everything beta-3, it stopped working. Debugging, I found that the beta-3 core engine doesn't work in the environment of the adapter. I think I know why and I'll work on it after this release. I think that what happened was that the beta 2 engine kept being used until I changed what was used by the tests... probably because the tests are built last.

For this release, all framework references are to beta 3. I had to fix some tests as a result. All engine references are still using beta 2, since beta 3 is broken. Both the vsix and the nuget package are working for me.

One lesson: keep all the package references consistent or we may not know what assembly is actually being used.

Another one: separate feature updates from changes to what version of NUnit we use in future.