### PR TITLE
Better error message when no NUnit 3 tests are found. Fixes #57

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -65,7 +65,11 @@ namespace NUnit.VisualStudio.TestAdapter
                         }
                         else
                         {
-                            TestLog.NUnitLoadError(sourceAssembly);
+                            var msgNode = loadResult.SelectSingleNode("properties/property[@name='_SKIPREASON']");
+                            if (msgNode != null && msgNode.GetAttribute("value").Contains("contains no tests"))
+                                TestLog.SendWarningMessage("Assembly contains no NUnit 3.0 tests: " + sourceAssembly);
+                            else
+                                TestLog.NUnitLoadError(sourceAssembly);
                         }
                     }
                     catch (BadImageFormatException)


### PR DESCRIPTION
In order to avoid confusing users, we now say that no NUnit 3.0 tests were found.

This is implemented by checking the content of the message that accompanies the non-loadable test. It's not a good long-term solution so I have created an issue around it.