### PR TITLE
Remove all but one async void demo test

### DIFF
--- a/demo/NUnitTestDemo/AsyncTests.cs
+++ b/demo/NUnitTestDemo/AsyncTests.cs
@@ -7,28 +7,12 @@ namespace NUnitTestDemo
 {
 	public class AsyncTests
 	{
-		[Test, ExpectPass]
-		public async void AsyncVoidTestSucceeds()
-		{
-			var result = await ReturnOne();
-
-			Assert.AreEqual(1, result);
-		}
-
-		[Test, ExpectFailure]
-		public async void AsyncVoidTestFails()
-		{
-			var result = await ReturnOne();
-
-			Assert.AreEqual(2, result);
-		}
-
 		[Test, ExpectError]
-		public async void AsyncVoidTestThrowsException()
+		public async void AsyncVoidTestIsInvalid()
 		{
-			await ThrowException();
+            var result = await ReturnOne();
 
-			Assert.Fail("Should never get here");
+            Assert.AreEqual(1, result);
 		}
 
 		[Test, ExpectPass]


### PR DESCRIPTION
This was done as part of issue #27 but does not close it. It turns out that NUnit itself is still at fault. This PR just updates the tests to remove async void tests except for a single one that demonstrates that such tests are not vaild.

I'll merge this immedieately.