### PR TITLE
Fix version number problems in ctp-7

### DIFF
--- a/nunit3-vs-adapter.build
+++ b/nunit3-vs-adapter.build
@@ -7,7 +7,7 @@
 
 
     <!-- Set version number for package -->
-    <property name="package.version" value="3.0.7-ctp-7"/>
+    <property name="package.version" value="3.0.7-ctp-7b"/>
 
     <!-- Define package name, including version -->
     <property name="package.base.name" value="NUnit3TestAdapter"/>

--- a/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
+++ b/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 [assembly: Guid("c0aad5e4-b486-49bc-b3e8-31e01be6fefe")]
-[assembly: AssemblyVersion("3.0.6.0")]
-[assembly: AssemblyFileVersion("3.0.6.0")]
+[assembly: AssemblyVersion("3.0.7.0")]
+[assembly: AssemblyFileVersion("3.0.7.0")]

--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -3,8 +3,10 @@
   <Identifier Id="NUnit.NUnit3TestAdapter">
     <Name>NUnit3 Test Adapter</Name>
     <Author>Charlie Poole</Author>
-    <Version>3.0.6.0</Version>
-    <Description xml:space="preserve">NUnit 3.0 adapter for integrated test execution under Visual Studio 2012 (all updates), Visual Studio 2013 (all updates), and the Visual Studio 2015 Preview and CTPs. Compatible with NUnit 3.0.</Description>
+    <Version>3.0.7.0</Version>
+    <Description xml:space="preserve">NUnit 3.0 adapter for integrated test execution under Visual Studio 2012 (all updates), Visual Studio 2013 (all updates), and the Visual Studio 2015 Preview and CTPs. Compatible with NUnit 3.0.
+    
+    NOTE: This package replaces the earlier CTP-7 release, which mistakenly carried an internal version of 3.0.6.</Description>
     <Locale>1033</Locale>
     <MoreInfoUrl>http://nunit.org/index.php?p=vsTestAdapter&amp;r=3.0</MoreInfoUrl>
     <License>license.rtf</License>


### PR DESCRIPTION
The AssemblyInfo and the vsix package both had 3.0.6