### PR TITLE
AsyncMethodHelper handles overloaded methods.  Fixes exception #104

### DIFF
--- a/src/NUnitTestAdapter/Internal/AsyncMethodHelper.cs
+++ b/src/NUnitTestAdapter/Internal/AsyncMethodHelper.cs
@@ -24,7 +24,7 @@ namespace NUnit.VisualStudio.TestAdapter.Internal
             var definingType = targetAssembly.GetType(className);
             if (definingType == null) return null;
 
-            var method = definingType.GetMethod(methodName);
+            var method = definingType.GetMethods().Where(o => o.Name == methodName).OrderBy(o => o.GetParameters().Length).FirstOrDefault();
             if (method == null) return null;
 
             var asyncAttribute = GetAsyncStateMachineAttribute(method);

--- a/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
+++ b/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
@@ -21,5 +21,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 [assembly: Guid("c0aad5e4-b486-49bc-b3e8-31e01be6fefe")]
-[assembly: AssemblyVersion("3.0.8.0")]
-[assembly: AssemblyFileVersion("3.0.8.0")]
+[assembly: AssemblyVersion("3.0.8.1")]
+[assembly: AssemblyFileVersion("3.0.8.1")]

--- a/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
+++ b/src/NUnitTestAdapterInstall/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
   <Identifier Id="NUnit.NUnit3TestAdapter">
     <Name>NUnit3 Test Adapter</Name>
     <Author>Charlie Poole</Author>
-    <Version>3.0.8.0</Version>
+    <Version>3.0.8.1</Version>
     <Description xml:space="preserve">NUnit 3.0 adapter for integrated test execution under Visual Studio 2012 (all updates), Visual Studio 2013 (all updates), and the Visual Studio 2015 Preview and CTPs. Compatible with NUnit 3.0.
     
     NOTE: This package replaces the earlier CTP-7 release, which mistakenly carried an internal version of 3.0.6.</Description>


### PR DESCRIPTION
Same change as for the 2.0 adapter, see https://github.com/nunit/nunit-vs-adapter/pull/95 