### PR TITLE
Changed message level for detection of nunit 2 tests  #109

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -67,7 +67,7 @@ namespace NUnit.VisualStudio.TestAdapter
                         {
                             var msgNode = loadResult.SelectSingleNode("properties/property[@name='_SKIPREASON']");
                             if (msgNode != null && msgNode.GetAttribute("value").Contains("contains no tests"))
-                                TestLog.SendWarningMessage("Assembly contains no NUnit 3.0 tests: " + sourceAssembly);
+                                TestLog.SendInformationalMessage("Assembly contains no NUnit 3.0 tests: " + sourceAssembly);
                             else
                                 TestLog.NUnitLoadError(sourceAssembly);
                         }

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -48,7 +48,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public void NUnitLoadError(string sourceAssembly)
         {
-            SendErrorMessage("NUnit failed to load " + sourceAssembly);
+            SendInformationalMessage("NUnit failed to load " + sourceAssembly);
         }
 
         public void SendErrorMessage(string message)


### PR DESCRIPTION
I changed the message level from Error to Informational on two places.  It might be that the semantics of NUnitLoadError has changed from V2 adapter to V3 adapter.  In the discoverer there is an explicit check, which I see in the repro that is being triggered, but in the executor there are no such ones, so I did the change both places.  