### PR TITLE
CU Build for Adapter

### DIFF
--- a/src/NUnitTestAdapterInstall/NUnit3TestAdapterInstall.csproj
+++ b/src/NUnitTestAdapterInstall/NUnit3TestAdapterInstall.csproj
@@ -71,7 +71,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DeployExtension>True</DeployExtension>
+    <DeployExtension Condition="'$(AppVeyor)' != ''">True</DeployExtension>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -83,7 +83,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-    <DeployExtension>True</DeployExtension>
+    <DeployExtension Condition="'$(AppVeyor)' != ''">False</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
@@ -145,8 +145,11 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(ourCase.DisplayName, Is.EqualTo(FakeTestData.DisplayName));
             Assert.That(ourCase.FullyQualifiedName, Is.EqualTo(FakeTestData.FullyQualifiedName));
             Assert.That(ourCase.Source, Is.EqualTo(FakeTestData.AssemblyPath));
-            Assert.That(ourCase.CodeFilePath, Is.SamePath(FakeTestData.CodeFile));
-            Assert.That(ourCase.LineNumber, Is.EqualTo(FakeTestData.LineNumber));
+            if (ourCase.CodeFilePath != null) // Unavailable if not running under VS
+            {
+                Assert.That(ourCase.CodeFilePath, Is.SamePath(FakeTestData.CodeFile));
+                Assert.That(ourCase.LineNumber, Is.EqualTo(FakeTestData.LineNumber));
+            }
         }
 
         private void VerifyTestResult(VSTestResult ourResult)

--- a/src/NUnitTestAdapterTests/NavigationDataTests.cs
+++ b/src/NUnitTestAdapterTests/NavigationDataTests.cs
@@ -5,6 +5,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 {
     using Fakes;
 
+    [Category("Navigation")]
     public class NavigationDataTests
     {
         TestConverter testConverter;

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -85,8 +85,11 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(testCase.DisplayName, Is.EqualTo(FakeTestData.DisplayName));
             Assert.That(testCase.Source, Is.SamePath(FakeTestData.AssemblyPath));
 
-            Assert.That(testCase.CodeFilePath, Is.SamePath(FakeTestData.CodeFile));
-            Assert.That(testCase.LineNumber, Is.EqualTo(FakeTestData.LineNumber));
+            if (testCase.CodeFilePath != null) // Unavailable if not running under VS
+            {
+                Assert.That(testCase.CodeFilePath, Is.SamePath(FakeTestData.CodeFile));
+                Assert.That(testCase.LineNumber, Is.EqualTo(FakeTestData.LineNumber));
+            }
 
             // Check traits using reflection, since the feature was added
             // in an update to VisualStudio and may not be present.


### PR DESCRIPTION
This fixes #2.

The build doesn't use a script, just the online AppVeyor settings for the nunit3-vs-adapter project.

Because we can't get the location of the tests in the codebase when we are not running under VS, the tests in category "Navigation" are excluded on AppVeyor.

Deployment of the vsix is not done under AppVeyor either.

