### PR TITLE
Add comment to ignore.addins so it's not zero length. 

### DIFF
--- a/src/NUnitTestAdapterInstall/ignore.addins
+++ b/src/NUnitTestAdapterInstall/ignore.addins
@@ -1,0 +1,1 @@
+# Empty addins file so that the engine doesn't examine every file in the directory


### PR DESCRIPTION
Fixes #118.

This is really all I can see to do on the adapter side. Anybody see anything else to do ?

@rprouse has suggested some error checking in reading the addins files, but that would be an issue for the engine rather than the adapter.