### PR TITLE
Revert to 3.0.1 test engine

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -60,16 +60,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.engine, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\nunit.engine.dll</HintPath>
+    <Reference Include="nunit.engine, Version=3.0.5813.39036, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit.engine.dll</HintPath>
       <Private>True</Private>
       <Aliases>ENG</Aliases>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NUnitTestAdapter/packages.config
+++ b/src/NUnitTestAdapter/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.VisualStudio.TestPlatform.ObjectModel" version="0.0.3" targetFramework="net35" />
-  <package id="NUnit.Engine" version="3.2.0" targetFramework="net35" />
+  <package id="NUnit.Engine" version="3.0.1" targetFramework="net35" />
 </packages>

--- a/src/NUnitTestAdapterInstall/NUnit3TestAdapterInstall.csproj
+++ b/src/NUnitTestAdapterInstall/NUnit3TestAdapterInstall.csproj
@@ -141,15 +141,23 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.engine, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\nunit.engine.dll</HintPath>
+    <Reference Include="nunit-agent, Version=3.0.5813.39036, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit-agent.exe</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit-agent-x86, Version=3.0.5813.39036, Culture=neutral, processorArchitecture=x86">
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit-agent-x86.exe</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.engine, Version=3.0.5813.39036, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit.engine.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/NUnitTestAdapterInstall/packages.config
+++ b/src/NUnitTestAdapterInstall/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine" version="3.2.0" targetFramework="net45" />
+  <package id="NUnit.Engine" version="3.0.1" targetFramework="net45" />
 </packages>

--- a/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
@@ -41,15 +41,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\Mono.Cecil.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.engine, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\nunit.engine.dll</HintPath>
+    <Reference Include="nunit.engine, Version=3.0.5813.39036, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit.engine.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.2.0\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/NUnitTestAdapterTests/packages.config
+++ b/src/NUnitTestAdapterTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.VisualStudio.TestPlatform.ObjectModel" version="0.0.3" targetFramework="net45" />
   <package id="NUnit" version="3.2.0" targetFramework="net45" />
-  <package id="NUnit.Engine" version="3.2.0" targetFramework="net45" />
+  <package id="NUnit.Engine" version="3.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The 3.2 test engine is causing errors in the adapter, which weren't detected originally. I'm reverting to 3.0.1 for the 3.0 adapter release. We may need some fixes in the 3.2 engine before we can use it for the adapter.