### PR TITLE
Ensure that skipped tests (except ignored) are not shown as warnings

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -59,10 +59,6 @@
       <HintPath>..\..\packages\Microsoft.VisualStudio.TestPlatform.ObjectModel.0.0.3\lib\net35\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="nunit.engine, Version=3.0.5813.39036, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.Engine.3.0.1\lib\nunit.engine.dll</HintPath>
       <Private>True</Private>

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -187,7 +187,9 @@ namespace NUnit.VisualStudio.TestAdapter
                 case "Failed":
                     return TestOutcome.Failed;
                 case "Skipped":
-                    return TestOutcome.Skipped;
+                    return resultNode.GetAttribute("label")=="Ignored"
+                        ? TestOutcome.Skipped
+                        : TestOutcome.None;
                 default:
                     return TestOutcome.None;
             }

--- a/src/NUnitTestAdapterTests/TestConverterTests_StaticHelpers.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests_StaticHelpers.cs
@@ -17,7 +17,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [TestCase("<test-case result='Skipped' label='Ignored'/>", ExpectedResult = TestOutcome.Skipped)]
         [TestCase("<test-case result='Inconclusive'/>", ExpectedResult = TestOutcome.None)]
         [TestCase("<test-case result='Failed' label='NotRunnable'/>", ExpectedResult = TestOutcome.Failed)]
-        [TestCase("<test-case result='Skipped'/>", ExpectedResult = TestOutcome.Skipped)]
+        [TestCase("<test-case result='Skipped'/>", ExpectedResult = TestOutcome.None)]
         [TestCase("<test-case result='Passed'/>", ExpectedResult = TestOutcome.Passed)]
         public TestOutcome ResultStateToTestOutcome(string result)
         {

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -98,8 +98,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             // NOTE: One inconclusive test is reported as None
             new TestCaseData(TestOutcome.Passed).Returns(MockAssembly.Success),
             new TestCaseData(TestOutcome.Failed).Returns(MockAssembly.ErrorsAndFailures),
-            new TestCaseData(TestOutcome.Skipped).Returns(MockAssembly.Ignored + MockAssembly.Explicit),
-            new TestCaseData(TestOutcome.None).Returns(1),
+            new TestCaseData(TestOutcome.Skipped).Returns(MockAssembly.Ignored),
+            new TestCaseData(TestOutcome.None).Returns(MockAssembly.Explicit + 1),
             new TestCaseData(TestOutcome.NotFound).Returns(0)
         };
 


### PR DESCRIPTION
Fixes issue #106 (again)