### PR TITLE
Support settings in a .runsettings file

### DIFF
--- a/demo/NUnit3TestDemo.sln
+++ b/demo/NUnit3TestDemo.sln
@@ -7,6 +7,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NUnit3TestDemo", "NUnitTest
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{7D4F02DA-26F6-4E82-AB17-A7296B35926A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7CE30108-5D81-4850-BE6B-C8BCA35D3592}"
+	ProjectSection(SolutionItems) = preProject
+		demo.runsettings = demo.runsettings
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/demo/NUnitTestDemo/TextOutputTests.cs
+++ b/demo/NUnitTestDemo/TextOutputTests.cs
@@ -31,5 +31,14 @@ namespace NUnitTestDemo
             Trace.Write("This is Trace line 3");
         }
 
+        [Test, Description("Displays various settings for verification")]
+        public void DisplayTestSettings()
+        {
+            Console.WriteLine("CurrentDirectory={0}", Environment.CurrentDirectory);
+            Console.WriteLine("BasePath={0}", AppDomain.CurrentDomain.BaseDirectory);
+            Console.WriteLine("PrivateBinPath={0}", AppDomain.CurrentDomain.SetupInformation.PrivateBinPath);
+            Console.WriteLine("WorkDirectory={0}", TestContext.CurrentContext.WorkDirectory);
+            Console.WriteLine("DefaultTimeout={0}", NUnit.Framework.Internal.TestExecutionContext.CurrentContext.TestCaseTimeout);
+        }
     }
 }

--- a/demo/demo.runsettings
+++ b/demo/demo.runsettings
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <!-- Configurations that affect the Test Framework -->
+  <RunConfiguration>
+    <!-- Path relative to solution directory -->
+    <ResultsDirectory>.\TestResults</ResultsDirectory>
+
+    <!-- [x86] | x64  
+      - You can also change it from menu Test, Test Settings, Default Processor Architecture -->
+    <TargetPlatform>x86</TargetPlatform>
+
+    <!-- Framework35 | [Framework40] | Framework45 -->
+    <TargetFrameworkVersion>Framework40</TargetFrameworkVersion>
+
+  </RunConfiguration>
+
+  <!-- Parameters used by tests at runtime -->
+  <TestRunParameters>
+    <Parameter name="webAppUrl" value="http://localhost" />
+    <Parameter name="webAppUserName" value="Admin" />
+    <Parameter name="webAppPassword" value="Password" />
+  </TestRunParameters>
+
+  <!-- Adapter Specific sections -->
+
+</RunSettings>

--- a/demo/demo.runsettings
+++ b/demo/demo.runsettings
@@ -27,6 +27,7 @@
     <PrivateBinPath>extras;more.extras</PrivateBinPath>
     <DefaultTimeout>5000</DefaultTimeout>
     <WorkDirectory>work</WorkDirectory>
+    <InternalTraceLevel>Info</InternalTraceLevel>
   </NUnit>
 
 </RunSettings>

--- a/demo/demo.runsettings
+++ b/demo/demo.runsettings
@@ -22,5 +22,11 @@
   </TestRunParameters>
 
   <!-- Adapter Specific sections -->
+  <NUnit>
+    <BasePath>D:\Dev\NUnit\nunit3-vs-adapter\demo\NUnitTestDemo\bin\Release</BasePath>
+    <PrivateBinPath>extras;more.extras</PrivateBinPath>
+    <DefaultTimeout>5000</DefaultTimeout>
+    <WorkDirectory>work</WorkDirectory>
+  </NUnit>
 
 </RunSettings>

--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace NUnit.VisualStudio.TestAdapter
+{
+    public class AdapterSettings
+    {
+        private XmlNode _runConfiguration;
+        private XmlNode _testRunParameters;
+        private XmlNode _nunitAdapter;
+
+        #region Properties
+
+        public string MaxCpuCount
+        {
+            get { return GetInnerText(_runConfiguration, "MaxCpuCount"); }
+        }
+
+        public string ResultsDirectory
+        {
+            get { return GetInnerText(_runConfiguration, "ResultsDirectory"); }
+        }
+
+        public string TargetPlatform
+        {
+            get { return GetInnerText(_runConfiguration, "TargetPlatform"); }
+        }
+
+        public string TargetFrameworkVersion
+        {
+            get { return GetInnerText(_runConfiguration, "TargetFrameworkVersion"); }
+        }
+
+        public string TestAdapterPaths
+        {
+            get { return GetInnerText(_runConfiguration, "TestAdapterPaths"); }
+        }
+
+        private Dictionary<string, string> _testProperties;
+        public IDictionary<string, string> TestProperties
+        {
+            get
+            {
+                if (_testProperties == null)
+                {
+                    _testProperties = new Dictionary<string, string>();
+
+                    if (_testRunParameters != null)
+                    {
+                        foreach (XmlNode node in _testRunParameters.SelectNodes("Property"))
+                        {
+                            var key = node.GetAttribute("name");
+                            var value = node.GetAttribute("value");
+                            if (key != null && value != null)
+                                _testProperties.Add(key, value);
+                        }
+                    }
+                }
+
+                return _testProperties;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public void Load(IDiscoveryContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException("context", "Load called with null context");
+
+            Load(context.RunSettings.SettingsXml);
+        }
+
+        public void Load(string settingsXml)
+        {
+            if (settingsXml == null)
+                throw new ArgumentNullException("settingsXml", "Load called with null XML string");
+            if (settingsXml == string.Empty)
+                throw new ArgumentException("settingsXml", "Load called with empty XML string");
+
+            var doc = new XmlDocument();
+            doc.LoadXml(settingsXml);
+            _runConfiguration = doc.SelectSingleNode("RunSettings/RunConfiguration");
+            _testRunParameters = doc.SelectSingleNode("RunSettings/TestRunParameters");
+            _nunitAdapter = doc.SelectSingleNode("RunSettings/NUnit");
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private string GetInnerText(XmlNode startNode, string xpath)
+        {
+            if (startNode != null)
+            {
+                var targetNode = startNode.SelectSingleNode(xpath);
+                if (targetNode != null)
+                    return targetNode.InnerText;
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -74,6 +74,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AdapterSettings.cs" />
     <Compile Include="NUnitEventListener.cs" />
     <Compile Include="Internal\AsyncMethodHelper.cs" />
     <Compile Include="Internal\Stackframe.cs" />

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -30,7 +30,7 @@ namespace NUnit.VisualStudio.TestAdapter
             if (!Debugger.IsAttached)
                 Debugger.Launch();
 #endif
-            Initialize(messageLogger);
+            Initialize(discoveryContext, messageLogger);
 
             Info("discovering tests", "started");
 

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -23,11 +23,6 @@ namespace NUnit.VisualStudio.TestAdapter
     [ExtensionUri(ExecutorUri)]
     public sealed class NUnit3TestExecutor : NUnitTestAdapter, ITestExecutor, IDisposable
     {
-        ///<summary>
-        /// The Uri used to identify the NUnitExecutor
-        ///</summary>
-        public const string ExecutorUri = "executor://NUnit3TestExecutor";
-
         // TFS Filter in effect - may be empty
         private TfsTestFilter _tfsFilter;
 
@@ -51,7 +46,7 @@ namespace NUnit.VisualStudio.TestAdapter
             if (!Debugger.IsAttached)
                 Debugger.Launch();
 #endif
-            Initialize(frameworkHandle);
+            Initialize(runContext, frameworkHandle);
 
             try
             {
@@ -101,7 +96,7 @@ namespace NUnit.VisualStudio.TestAdapter
             if (!Debugger.IsAttached)
                 Debugger.Launch();
 #endif
-            Initialize(frameworkHandle);
+            Initialize(runContext, frameworkHandle);
 
             var enableShutdown = (UseVsKeepEngineRunning) ? !runContext.KeepAlive : true;
             frameworkHandle.EnableShutdownAfterTestRun = enableShutdown;
@@ -147,9 +142,9 @@ namespace NUnit.VisualStudio.TestAdapter
         // The TestExecutor is constructed using the default constructor.
         // We don't have any info to initialize it until one of the
         // ITestExecutor methods is called.
-        protected override void Initialize(IMessageLogger messageLogger)
+        protected override void Initialize(IDiscoveryContext context, IMessageLogger messageLogger)
         {
-            base.Initialize(messageLogger);
+            base.Initialize(context, messageLogger);
 
             Info("executing tests", "started");
 

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -52,7 +52,7 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 _tfsFilter = new TfsTestFilter(runContext);
                 TestLog.SendDebugMessage("Keepalive:" + runContext.KeepAlive);
-                var enableShutdown = (UseVsKeepEngineRunning) ? !runContext.KeepAlive : true;
+                var enableShutdown = (Settings.UseVsKeepEngineRunning) ? !runContext.KeepAlive : true;
                 if (!_tfsFilter.HasTfsFilterValue)
                 {
                     if (!(enableShutdown && !runContext.KeepAlive))  // Otherwise causes exception when run as commandline, illegal to enableshutdown when Keepalive is false, might be only VS2012
@@ -98,7 +98,7 @@ namespace NUnit.VisualStudio.TestAdapter
 #endif
             Initialize(runContext, frameworkHandle);
 
-            var enableShutdown = (UseVsKeepEngineRunning) ? !runContext.KeepAlive : true;
+            var enableShutdown = (Settings.UseVsKeepEngineRunning) ? !runContext.KeepAlive : true;
             frameworkHandle.EnableShutdownAfterTestRun = enableShutdown;
             Debug("executing tests", "EnableShutdown set to " + enableShutdown);
 

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Remoting.Channels;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using NUnit.Common;
 using NUnit.Engine;
@@ -27,7 +28,31 @@ namespace NUnit.VisualStudio.TestAdapter
     /// </summary>
     public abstract class NUnitTestAdapter
     {
+        #region Constants
+
+        ///<summary>
+        /// The Uri used to identify the NUnitExecutor
+        ///</summary>
+        public const string ExecutorUri = "executor://NUnit3TestExecutor";
+
+        public const string SettingsName = "NUnitAdapterSettings";
+
+        #endregion
+
+        #region Constructor
+
+        public NUnitTestAdapter()
+        {
+            Verbosity = 0;
+            AdapterVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            Settings = new AdapterSettings();
+        }
+
+        #endregion
+
         #region Properties
+
+        public AdapterSettings Settings { get; private set; }
 
         // The adapter version
         private string AdapterVersion { get; set; }
@@ -73,11 +98,13 @@ namespace NUnit.VisualStudio.TestAdapter
         // We don't have any info to initialize it until one of the
         // ITestDiscovery or ITestExecutor methods is called. The
         // each Discover or Execute method must call this method.
-        protected virtual void Initialize(IMessageLogger messageLogger)
+        protected virtual void Initialize(IDiscoveryContext context, IMessageLogger messageLogger)
         {
-            Verbosity = 0; // In case we throw below
-            AdapterVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            Settings.Load(context);
 
+            //var settingsProvider = runSettings.GetSettings(SettingsName) as NUnitAdapterSettingsProvider;
+            //var settings = settingsProvider != null ? settingsProvider.Settings : new NUnitAdapterSettings(); 
+            
             try
             {
                 var registry = RegistryCurrentUser.OpenRegistryCurrentUser(@"Software\nunit.org\VSAdapter");

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -165,7 +165,13 @@ namespace NUnit.VisualStudio.TestAdapter
             package.Settings[PackageSettings.DomainUsage] = "Single";
 
             // Set the work directory to the assembly location unless a setting is provided
-            package.Settings[PackageSettings.WorkDirectory] = Settings.WorkDirectory ?? Path.GetDirectoryName(assemblyName);
+            var workDir = Settings.WorkDirectory;
+            if (workDir == null)
+                workDir = Path.GetDirectoryName(assemblyName);
+            else if (!Path.IsPathRooted(workDir))
+                workDir = Path.Combine(Path.GetDirectoryName(assemblyName), workDir);
+            package.Settings[PackageSettings.WorkDirectory] = workDir;
+
             return package;
         }
 

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -170,6 +170,8 @@ namespace NUnit.VisualStudio.TestAdapter
                 workDir = Path.GetDirectoryName(assemblyName);
             else if (!Path.IsPathRooted(workDir))
                 workDir = Path.Combine(Path.GetDirectoryName(assemblyName), workDir);
+            if (!Directory.Exists(workDir))
+                Directory.CreateDirectory(workDir);
             package.Settings[PackageSettings.WorkDirectory] = workDir;
 
             return package;

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -40,7 +40,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void DefaultSettings()
         {
             _settings.Load("<RunSettings/>");
-            Assert.Null(_settings.MaxCpuCount);
+            Assert.That(_settings.MaxCpuCount, Is.EqualTo(-1));
             Assert.Null(_settings.ResultsDirectory);
             Assert.Null(_settings.TargetFrameworkVersion);
             Assert.Null(_settings.TargetPlatform);
@@ -69,7 +69,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void MaxCpuCountSetting()
         {
             _settings.Load("<RunSettings><RunConfiguration><MaxCpuCount>42</MaxCpuCount></RunConfiguration></RunSettings>");
-            Assert.That(_settings.MaxCpuCount, Is.EqualTo("42"));
+            Assert.That(_settings.MaxCpuCount, Is.EqualTo(42));
         }
 
         [Test]

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using NUnit.Framework;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests
+{
+    public class AdapterSettingsTests
+    {
+        private AdapterSettings _settings;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _settings = new AdapterSettings();
+        }
+
+        [Test]
+        public void NullContextThrowsException()
+        {
+            Assert.That(() => _settings.Load((IDiscoveryContext)null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void NullStringThrowsException()
+        {
+            Assert.That(() => _settings.Load((string)null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void EmptyStringThrowsException()
+        {
+            Assert.That(() => _settings.Load(string.Empty), Throws.ArgumentException);
+        }
+
+        [Test]
+        public void DefaultSettings()
+        {
+            _settings.Load("<RunSettings/>");
+            Assert.Null(_settings.MaxCpuCount);
+            Assert.Null(_settings.ResultsDirectory);
+            Assert.Null(_settings.TargetFrameworkVersion);
+            Assert.Null(_settings.TargetPlatform);
+            Assert.Null(_settings.TestAdapterPaths);
+            Assert.IsEmpty(_settings.TestProperties);
+        }
+
+        [Test]
+        public void ResultsDirectorySetting()
+        {
+            _settings.Load("<RunSettings><RunConfiguration><ResultsDirectory>./myresults</ResultsDirectory></RunConfiguration></RunSettings>");
+            Assert.That(_settings.ResultsDirectory, Is.EqualTo("./myresults"));
+        }
+
+        [Test]
+        public void MaxCpuCountSetting()
+        {
+            _settings.Load("<RunSettings><RunConfiguration><MaxCpuCount>42</MaxCpuCount></RunConfiguration></RunSettings>");
+            Assert.That(_settings.MaxCpuCount, Is.EqualTo("42"));
+        }
+
+        [Test]
+        public void TargetFrameworkVersionSetting()
+        {
+            _settings.Load("<RunSettings><RunConfiguration><TargetFrameworkVersion>Framework45</TargetFrameworkVersion></RunConfiguration></RunSettings>");
+            Assert.That(_settings.TargetFrameworkVersion, Is.EqualTo("Framework45"));
+        }
+
+        [Test]
+        public void TargetPlatformSetting()
+        {
+            _settings.Load("<RunSettings><RunConfiguration><TargetPlatform>x86</TargetPlatform></RunConfiguration></RunSettings>");
+            Assert.That(_settings.TargetPlatform, Is.EqualTo("x86"));
+        }
+
+        [Test]
+        public void TestAdapterPathsSetting()
+        {
+            _settings.Load("<RunSettings><RunConfiguration><TestAdapterPaths>/first/path;/second/path</TestAdapterPaths></RunConfiguration></RunSettings>");
+            Assert.That(_settings.TestAdapterPaths, Is.EqualTo("/first/path;/second/path"));
+        }
+
+        public void TestRunParameterSettings()
+        {
+            _settings.Load("<RunSettings><TestRunParameters><Parameter name='Answer' value=42/><Parameter name='Question' value='Why?'/></TestRunParameters></RunSettings>");
+            Assert.That(_settings.TestProperties.Count, Is.EqualTo(2));
+            Assert.That(_settings.TestProperties["Answer"], Is.EqualTo("42"));
+            Assert.That(_settings.TestProperties["Question"], Is.EqualTo("Why?"));
+        }
+    }
+}

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -46,6 +46,16 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.Null(_settings.TargetPlatform);
             Assert.Null(_settings.TestAdapterPaths);
             Assert.IsEmpty(_settings.TestProperties);
+            Assert.Null(_settings.InternalTraceLevel);
+            Assert.Null(_settings.WorkDirectory);
+            Assert.That(_settings.NumberOfTestWorkers, Is.EqualTo(-1));
+            Assert.That(_settings.DefaultTimeout, Is.EqualTo(0));
+            Assert.That(_settings.Verbosity, Is.EqualTo(0));
+            Assert.False(_settings.ShadowCopyFiles);
+            Assert.False(_settings.UseVsKeepEngineRunning);
+            Assert.Null(_settings.BasePath);
+            Assert.Null(_settings.PrivateBinPath);
+            Assert.That(_settings.RandomSeed, Is.EqualTo(-1));
         }
 
         [Test]
@@ -83,12 +93,83 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(_settings.TestAdapterPaths, Is.EqualTo("/first/path;/second/path"));
         }
 
+        [Test]
         public void TestRunParameterSettings()
         {
-            _settings.Load("<RunSettings><TestRunParameters><Parameter name='Answer' value=42/><Parameter name='Question' value='Why?'/></TestRunParameters></RunSettings>");
+            _settings.Load("<RunSettings><TestRunParameters><Parameter name='Answer' value='42'/><Parameter name='Question' value='Why?'/></TestRunParameters></RunSettings>");
             Assert.That(_settings.TestProperties.Count, Is.EqualTo(2));
             Assert.That(_settings.TestProperties["Answer"], Is.EqualTo("42"));
             Assert.That(_settings.TestProperties["Question"], Is.EqualTo("Why?"));
+        }
+
+        [Test]
+        public void InternalTraceLevel()
+        {
+            _settings.Load("<RunSettings><NUnit><InternalTraceLevel>Debug</InternalTraceLevel></NUnit></RunSettings>");
+            Assert.That(_settings.InternalTraceLevel, Is.EqualTo("Debug"));
+        }
+
+        [Test]
+        public void WorkDirectorySetting()
+        {
+            _settings.Load("<RunSettings><NUnit><WorkDirectory>/my/work/dir</WorkDirectory></NUnit></RunSettings>");
+            Assert.That(_settings.WorkDirectory, Is.EqualTo("/my/work/dir"));
+        }
+
+        [Test]
+        public void NumberOfTestWorkersSetting()
+        {
+            _settings.Load("<RunSettings><NUnit><NumberOfTestWorkers>12</NumberOfTestWorkers></NUnit></RunSettings>");
+            Assert.That(_settings.NumberOfTestWorkers, Is.EqualTo(12));
+        }
+
+        [Test]
+        public void DefaultTimeoutSetting()
+        {
+            _settings.Load("<RunSettings><NUnit><DefaultTimeout>5000</DefaultTimeout></NUnit></RunSettings>");
+            Assert.That(_settings.DefaultTimeout, Is.EqualTo(5000));
+        }
+
+        [Test]
+        public void ShadowCopySetting()
+        {
+            _settings.Load("<RunSettings><NUnit><ShadowCopyFiles>true</ShadowCopyFiles></NUnit></RunSettings>");
+            Assert.True(_settings.ShadowCopyFiles);
+        }
+
+        [Test]
+        public void VerbositySetting()
+        {
+            _settings.Load("<RunSettings><NUnit><Verbosity>1</Verbosity></NUnit></RunSettings>");
+            Assert.That(_settings.Verbosity, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void UseVsKeepEngineRunningSetting()
+        {
+            _settings.Load("<RunSettings><NUnit><UseVsKeepEngineRunning>true</UseVsKeepEngineRunning></NUnit></RunSettings>");
+            Assert.True(_settings.UseVsKeepEngineRunning);
+        }
+
+        [Test]
+        public void BasePathSetting()
+        {
+            _settings.Load("<RunSettings><NUnit><BasePath>..</BasePath></NUnit></RunSettings>");
+            Assert.That(_settings.BasePath, Is.EqualTo(".."));
+        }
+
+        [Test]
+        public void PrivateBinPathSetting()
+        {
+            _settings.Load("<RunSettings><NUnit><PrivateBinPath>dir1;dir2</PrivateBinPath></NUnit></RunSettings>");
+            Assert.That(_settings.PrivateBinPath, Is.EqualTo("dir1;dir2"));
+        }
+
+        [Test]
+        public void RandomSeedSetting()
+        {
+            _settings.Load("<RunSettings><NUnit><RandomSeed>12345</RandomSeed></NUnit></RunSettings>");
+            Assert.That(_settings.RandomSeed, Is.EqualTo(12345));
         }
     }
 }

--- a/src/NUnitTestAdapterTests/Fakes/FakeDiscoveryContext.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeDiscoveryContext.cs
@@ -3,20 +3,21 @@
 // ****************************************************************
 
 using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
 {
-    class FakeRunSettings : IRunSettings
+    class FakeDiscoveryContext : IDiscoveryContext
     {
-        ISettingsProvider IRunSettings.GetSettings(string settingsName)
+        #region IDiscoveryContextMembers
+
+        IRunSettings IDiscoveryContext.RunSettings
         {
-            throw new NotImplementedException();
+            get { return new FakeRunSettings(); }
         }
 
-        public string SettingsXml
-        {
-            get { return "<RunSettings/>"; }
-        }
+        #endregion
     }
 }

--- a/src/NUnitTestAdapterTests/Fakes/FakeRunContext.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeRunContext.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
 {
-    class FakeRunContext : IRunContext
+    class FakeRunContext : FakeDiscoveryContext, IRunContext
     {
         #region IRunContext Members
 
@@ -47,16 +47,6 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
         }
 
         #endregion
-
-        #region IDiscoveryContextMembers
-
-        IRunSettings IDiscoveryContext.RunSettings
-        {
-            get { throw new NotImplementedException(); }
-        }
-
-        #endregion
-
 
         public string SolutionDirectory
         {

--- a/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit3TestAdapterTests.csproj
@@ -65,9 +65,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AdapterSettingsTests.cs" />
     <Compile Include="AssemblyRunnerTests.cs" />
     <Compile Include="AsyncTests.cs" />
     <Compile Include="ExperimentalTests.cs" />
+    <Compile Include="Fakes\FakeDiscoveryContext.cs" />
     <Compile Include="Fakes\FakeTestData.cs" />
     <Compile Include="Fakes\MessageLoggerStub.cs" />
     <Compile Include="IssueNo24Tests.cs" />

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2011-2015 NUnit Software. All rights reserved.
 // ****************************************************************
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -11,8 +12,10 @@ using NUnit.Framework;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
 {
+    using Fakes;
+
     [Category("TestDiscovery")]
-    public class TestDiscoveryTests : IMessageLogger, ITestCaseDiscoverySink
+    public class TestDiscoveryTests : ITestCaseDiscoverySink
     {
         static readonly string MockAssemblyPath = 
             Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
@@ -31,7 +34,11 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             // Load the NUnit mock-assembly.dll once for this test, saving
             // the list of test cases sent to the discovery sink
             nunittestDiscoverer = ((ITestDiscoverer)new NUnit3TestDiscoverer());
-            nunittestDiscoverer.DiscoverTests(new[] { MockAssemblyPath}, null, this, this);
+            nunittestDiscoverer.DiscoverTests(
+                new[] { MockAssemblyPath}, 
+                new FakeDiscoveryContext(), 
+                new MessageLoggerStub(), 
+                this);
         }
 
         [Test]
@@ -50,14 +57,6 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(testCase.FullyQualifiedName, Is.EqualTo(fullName));
         }
 
-        #region IMessageLogger Methods
-
-        void IMessageLogger.SendMessage(TestMessageLevel testMessageLevel, string message)
-        {
-        }
-
-        #endregion
-
         #region ITestCaseDiscoverySink Methods
 
         void ITestCaseDiscoverySink.SendTestCase(TestCase discoveredTest)
@@ -69,7 +68,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
     }
 
     [Category("TestDiscovery")]
-    public class EmptyAssemblyDiscoveryTests : IMessageLogger, ITestCaseDiscoverySink
+    public class EmptyAssemblyDiscoveryTests : ITestCaseDiscoverySink
     {
         static readonly string EmptyAssemblyPath = 
             Path.Combine(TestContext.CurrentContext.TestDirectory, "empty-assembly.dll");
@@ -81,19 +80,14 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         {
             // Load the NUnit empty-assembly.dll once for this test
             nunittestDiscoverer = ((ITestDiscoverer)new NUnit3TestDiscoverer());
-            nunittestDiscoverer.DiscoverTests(new[] { EmptyAssemblyPath}, null, this, this);
+            nunittestDiscoverer.DiscoverTests(
+                new[] { EmptyAssemblyPath}, 
+                new FakeDiscoveryContext(), 
+                new MessageLoggerStub(), 
+                this);
         }
 
-        #region IMessageLogger Methods
-
-        void IMessageLogger.SendMessage(TestMessageLevel testMessageLevel, string message)
-        {
-            Assert.That(message, Does.Not.Contain("failed to load"));
-        }
-
-        #endregion
-
-        #region ITestCaseDiscoverySink Methods
+         #region ITestCaseDiscoverySink Methods
 
         void ITestCaseDiscoverySink.SendTestCase(TestCase discoveredTest)
         {


### PR DESCRIPTION
This fixes #49 

The following Settings are supported under the NUnit element:

* BasePath (string)
* PrivateBinPath (string)
* InternalTraceLevel (string)
* WorkDirectory (string)
* NumberOfTestWorkers (int)
* DefaultTimeout (int)
* ShadowCopyFiles (bool)
* Verbosity (int)
* RandomSeed (int)
* UseVsKeepEngineRunning (bool)

The following requested items are __not Implemented__
* ProcessModel (currently fixed as InProcess)
* DomainUsage (currently fixed as a separate domain per test)
* TargetFramework (currently determined by VS)
* RunAsX86 (currently determined by VS)

In the current build, any registry settings are ignored. You must use the corresponding settings in the `.runsettings` file. There is code, currently conditioned out, which applies the registry settings for Verbosity, UseVsKeepEngineRunning and ShadowCopyFiles when those are not set in the file. My inclination, however, is to drop use of the registry entirely for the final 3.0 release.