### PR TITLE
Don't allow exceptions in the listener to flow back to NUnit

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -188,8 +188,6 @@ namespace NUnit.VisualStudio.TestAdapter
 
                 if (loadResult.GetAttribute("runstate") == "Runnable")
                 {
-                    TestLog.Info(string.Format("Loading tests from {0}", assemblyName));
-
                     var nunitTestCases = loadResult.SelectNodes("//test-case");
 
                     using (var testConverter = new TestConverter(TestLog, assemblyName))
@@ -201,6 +199,8 @@ namespace NUnit.VisualStudio.TestAdapter
                         // All future calls to convert a test case may now use the cache.
                         foreach (XmlNode testNode in nunitTestCases)
                             loadedTestCases.Add(testConverter.ConvertTestCase(testNode));
+
+                        TestLog.Info(string.Format("NUnit3TestExecutor converted {0} of {1} NUnit test cases", loadedTestCases.Count, nunitTestCases.Count));
 
                         // If we have a TFS Filter, convert it to an nunit filter
                         if (TfsFilter != null && !TfsFilter.IsEmpty)

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -42,19 +42,29 @@ namespace NUnit.VisualStudio.TestAdapter
         public void OnTestEvent(string report)
         {
             var node = XmlHelper.CreateXmlNode(report);
-            switch (node.Name)
+
+            try
             {
-                case "start-test":
-                    TestStarted(node);
-                    break;
+                switch (node.Name)
+                {
+                    case "start-test":
+                        TestStarted(node);
+                        break;
 
-                case "test-case":
-                    TestFinished(node);
-                    break;
+                    case "test-case":
+                        TestFinished(node);
+                        break;
 
-                case "test-suite":
-                    SuiteFinished(node);
-                    break;
+                    case "test-suite":
+                        SuiteFinished(node);
+                        break;
+                }
+            }
+            catch(Exception ex)
+            {
+                _recorder.SendMessage(TestMessageLevel.Error,
+                    string.Format("Error processing {0} event for {1}", node.Name, node.GetAttribute("fullname")));
+                _recorder.SendMessage(TestMessageLevel.Error, ex.ToString());
             }
         }
 
@@ -99,6 +109,7 @@ namespace NUnit.VisualStudio.TestAdapter
         public void TestFinished(XmlNode resultNode)
         {
             TestResult ourResult = _testConverter.ConvertTestResult(resultNode);
+
             _recorder.RecordEnd(ourResult.TestCase, ourResult.Outcome);
             _recorder.RecordResult(ourResult);
         }


### PR DESCRIPTION
This appears to at least partially fix #131 

We'll need to wait to see whether further problems arise. See the issue for details