### PR TITLE
[WIP] addressing #163

### DIFF
--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -28,7 +28,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void LoadMockassembly()
         {
             // Sanity check to be sure we have the correct version of mock-assembly.dll
-            Assert.That(NUnit.Tests.Assemblies.MockAssembly.Tests, Is.EqualTo(31),
+            Assert.That(NUnit.Tests.Assemblies.MockAssembly.Tests, Is.EqualTo(32),
                 "The reference to mock-assembly.dll appears to be the wrong version");
 
             // Load the NUnit mock-assembly.dll once for this test, saving

--- a/src/mock-assembly/MockAssembly.cs
+++ b/src/mock-assembly/MockAssembly.cs
@@ -40,7 +40,8 @@ namespace NUnit.Tests
 
             public const int Tests = MockTestFixture.Tests 
                         + Singletons.OneTestCase.Tests 
-                        + TestAssembly.MockTestFixture.Tests 
+                        + TestAssembly.MockTestFixture.Tests
+                        + InheritedTests.DerivedFixture.Tests
                         + IgnoredFixture.Tests
                         + ExplicitFixture.Tests
                         + BadFixture.Tests
@@ -197,6 +198,26 @@ namespace NUnit.Tests
             {
             }
         }
+    }
+
+    namespace InheritedTests
+    {
+        [TestFixture]
+        public abstract class BaseFixture
+        {
+            public const int Tests = 1;
+
+            [Test]
+            public void RunTest()
+            {
+            }
+        }
+
+        [TestFixture]
+        public class DerivedFixture : BaseFixture
+        {
+        }
+
     }
 
     [TestFixture, Ignore("BECAUSE")]


### PR DESCRIPTION
I'm trying to write a high-level test in mock-assembly to expose #163 as shown below. When I ran `NUnit.VisualStudio.TestAdapter.Tests.TestDiscoveryTests` tests, the problem surprisingly didn't happen.

I traced the tests under the debugger and found that the root cause for the problem now showing up was that `NUnit.VisualStudio.TestAdapter.TestConverter.DiaSession` failed to initialize a `Microsoft.VisualStudio.TestPlatform.ObjectModel.DiaSession` instance. The latter class is defined inside Microsoft.VisualStudio.TestPlatform.ObjectModel.dll assembly, installed by a package of the same name from NUnit MyGet Feed.

The failure to create an instance is due to Microsoft.VisualStudio.TestPlatform.ObjectModel.dll missing a dependency assembly, msdia110typelib_clr0200(; ildasm confirmed that). I couldn't find this assembly on my machine since I don't have visual studio 2012 installed. I'm using visual studio 2015 professional update 2, with which a newer version of the missing assembly, msdia140typelib_clr0200.dll comes bundled.

So my final conclusion is that the older assembly msdia110typelib_clr0200 should be bundled with Microsoft.VisualStudio.TestPlatform.ObjectModel package as well. I know this's a little digression from the original problem in #163 but it would help reproduce the problem via a test and later to propose a solution for it.

Appreciating if anyone can help me proceed through this.