### PR TITLE
Fix navigation data for methods defined in base classes

### DIFF
--- a/src/NUnitTestAdapter/Internal/AsyncMethodHelper.cs
+++ b/src/NUnitTestAdapter/Internal/AsyncMethodHelper.cs
@@ -10,23 +10,8 @@ namespace NUnit.VisualStudio.TestAdapter.Internal
 {
     public class AsyncMethodHelper : MarshalByRefObject
     {
-        Assembly targetAssembly;
-
-        public void LoadAssembly(string assemblyName)
+        public string GetClassNameForAsyncMethod(MethodInfo method)
         {
-            targetAssembly = Assembly.LoadFrom(assemblyName);
-        }
-
-        public string GetClassNameForAsyncMethod(string className, string methodName)
-        {
-            if (targetAssembly == null) return null;
-
-            var definingType = targetAssembly.GetType(className);
-            if (definingType == null) return null;
-
-            var method = definingType.GetMethods().Where(o => o.Name == methodName).OrderBy(o => o.GetParameters().Length).FirstOrDefault();
-            if (method == null) return null;
-
             var asyncAttribute = GetAsyncStateMachineAttribute(method);
             if (asyncAttribute == null) return null;
 

--- a/src/NUnitTestAdapterTests/NavigationDataTests.cs
+++ b/src/NUnitTestAdapterTests/NavigationDataTests.cs
@@ -1,25 +1,24 @@
 ﻿using System.IO;
 using NUnit.Framework;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
 {
     using Fakes;
 
-    [Category("Navigation")]
-    public class NavigationDataTests
+    class NoSourceMessageTrap : IMessageLogger
     {
-        TestConverter testConverter;
+        public void SendMessage(TestMessageLevel testMessageLevel, string message)
+        {
+            Assert.That(message, Does.Not.Contain("No source data found for"));
+        }
+    }
+
+    public abstract class NavigationDataFixture
+    {
+        protected TestConverter testConverter;
 
         const string Prefix = "NUnit.VisualStudio.TestAdapter.Tests.NavigationTestData";
-
-        [SetUp]
-        public void SetUp()
-        {
-            
-            testConverter = new TestConverter(
-                new TestLogger( new MessageLoggerStub(), 0), 
-                Path.Combine(TestContext.CurrentContext.TestDirectory, "NUnit.VisualStudio.TestAdapter.Tests.dll"));
-        }
 
         [TearDown]
         public void TearDown()
@@ -27,27 +26,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             testConverter.Dispose();
         }
 
-        [TestCase("", "EmptyMethod_OneLine", 9, 9, 9, 9)]
-        [TestCase("", "EmptyMethod_TwoLines", 12, 13, 13, 13)]
-        [TestCase("", "EmptyMethod_ThreeLines", 16, 17, 17, 17)]
-        [TestCase("", "EmptyMethod_LotsOfLines", 20, 23, 23, 23)]
-        [TestCase("", "SimpleMethod_Void_NoArgs", 26, 28, 29, 29)]
-        [TestCase("", "SimpleMethod_Void_OneArg", 32, 33, 35, 35)]
-        [TestCase("", "SimpleMethod_Void_TwoArgs", 38, 39, 41, 41)]
-        [TestCase("", "SimpleMethod_ReturnsInt_NoArgs", 44, 46, 46, 47)]
-        [TestCase("", "SimpleMethod_ReturnsString_OneArg", 50, 51, 51, 52)]
-        // Generic method uses simple name
-        [TestCase("", "GenericMethod_ReturnsString_OneArg", 55, 56, 56, 57)]
-        [TestCase("", "AsyncMethod_Void", 60, 62, 64, 64)]
-        [TestCase("", "AsyncMethod_Task", 67, 69, 71, 71)]
-        [TestCase("", "AsyncMethod_ReturnsInt", 74, 76, 78, 78)]
-        [TestCase("+NestedClass", "SimpleMethod_Void_NoArgs", 83, 85, 86, 86)]
-        [TestCase("+ParameterizedFixture", "SimpleMethod_ReturnsString_OneArg", 101, 102, 102, 103)]
-        // Generic Fixture requires ` plus type arg count
-        [TestCase("+GenericFixture`2", "Matches", 116, 117, 117, 118)]
-        [TestCase("+GenericFixture`2+DoublyNested", "WriteBoth", 132, 133, 134, 134)]
-        [TestCase("+GenericFixture`2+DoublyNested`1", "WriteAllThree", 151, 152, 153, 153)]
-        public void VerifyNavigationData(string suffix, string methodName, int minLineDebug, int minLineRelease, int maxLineRelease, int maxLineDebug)
+        protected void VerifyNavigationData(string suffix, string methodName, int minLineDebug, int minLineRelease, int maxLineRelease, int maxLineDebug)
         {
             // Get the navigation data - ensure names are spelled correctly!
             var className = Prefix + suffix;
@@ -76,6 +55,58 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(data.MaxLineNumber, Is.EqualTo(maxLineRelease));
             Assert.That(data.MinLineNumber, Is.EqualTo(minLineRelease));
 #endif
+        }
+    }
+
+    [Category("Navigation")]
+    public class NavigationDataTests : NavigationDataFixture
+    {
+        [SetUp]
+        public void SetUp()
+        {
+
+            testConverter = new TestConverter(
+                new TestLogger(new MessageLoggerStub(), 0),
+                Path.Combine(TestContext.CurrentContext.TestDirectory, "NUnit.VisualStudio.TestAdapter.Tests.dll"));
+        }
+
+        [TestCase("", "EmptyMethod_OneLine", 9, 9, 9, 9)]
+        [TestCase("", "EmptyMethod_TwoLines", 12, 13, 13, 13)]
+        [TestCase("", "EmptyMethod_ThreeLines", 16, 17, 17, 17)]
+        [TestCase("", "EmptyMethod_LotsOfLines", 20, 23, 23, 23)]
+        [TestCase("", "SimpleMethod_Void_NoArgs", 26, 28, 29, 29)]
+        [TestCase("", "SimpleMethod_Void_OneArg", 32, 33, 35, 35)]
+        [TestCase("", "SimpleMethod_Void_TwoArgs", 38, 39, 41, 41)]
+        [TestCase("", "SimpleMethod_ReturnsInt_NoArgs", 44, 46, 46, 47)]
+        [TestCase("", "SimpleMethod_ReturnsString_OneArg", 50, 51, 51, 52)]
+        // Generic method uses simple name
+        [TestCase("", "GenericMethod_ReturnsString_OneArg", 55, 56, 56, 57)]
+        [TestCase("", "AsyncMethod_Void", 60, 62, 64, 64)]
+        [TestCase("", "AsyncMethod_Task", 67, 69, 71, 71)]
+        [TestCase("", "AsyncMethod_ReturnsInt", 74, 76, 78, 78)]
+        [TestCase("+NestedClass", "SimpleMethod_Void_NoArgs", 83, 85, 86, 86)]
+        [TestCase("+ParameterizedFixture", "SimpleMethod_ReturnsString_OneArg", 101, 102, 102, 103)]
+        // Generic Fixture requires ` plus type arg count
+        [TestCase("+GenericFixture`2", "Matches", 116, 117, 117, 118)]
+        [TestCase("+GenericFixture`2+DoublyNested", "WriteBoth", 132, 133, 134, 134)]
+        [TestCase("+GenericFixture`2+DoublyNested`1", "WriteAllThree", 151, 152, 153, 153)]
+        public new void VerifyNavigationData(string suffix, string methodName, int minLineDebug, int minLineRelease, int maxLineRelease, int maxLineDebug)
+        {
+            base.VerifyNavigationData(suffix, methodName, minLineDebug, minLineRelease, maxLineRelease, maxLineDebug);
+        }
+    }
+
+    [Category("Navigation")]
+    public class InheritanceNavigationDataTests : NavigationDataFixture
+    {
+        [Test]
+        public void VerifyNavigationData()
+        {
+            testConverter = new TestConverter(
+                new TestLogger(new NoSourceMessageTrap(), 0),
+                Path.Combine(TestContext.CurrentContext.TestDirectory, "NUnit.VisualStudio.TestAdapter.Tests.dll"));
+
+            VerifyNavigationData("+DerivedClass", "EmptyMethod_ThreeLines", 160, 161, 161, 161);
         }
     }
 }

--- a/src/NUnitTestAdapterTests/NavigationTestData.cs
+++ b/src/NUnitTestAdapterTests/NavigationTestData.cs
@@ -153,5 +153,16 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 } // maxLineDebug = maxLineRelease = 153
             }
         }
-    }
+
+        public abstract class BaseClass
+        {
+            public void EmptyMethod_ThreeLines()
+            { // minLineDebug = 160
+            } // minLineRelease = maxLineDebug = maxLineRelease = 161
+        }
+
+        public class DerivedClass : BaseClass
+        {
+        }
+}
 }


### PR DESCRIPTION
This's another trial to address #163. I'm pretty sure this PR is far from being accepted in its current form as it most probably needs a huge rework.

I first wrote a test case directly around the buggy part(getting navigation data from `TestConverter`). Some notes about the test code in the first commit are:

1. I needed a special `IMessageLogger` other than `MessageLoggerStub` used in many test cases, hence `NoSourceMessageTrap` came into existence. I didn't want to mess up with `MessageLoggerStub` as it's already used in other test cases and I didn't want to introduce any regressions. I defined the new class inside the same file as it's only used by my new test case(for the time being).
2. I didn't feel I would benefit from how the test converter test object is configured by the SetUp fixture and that was why I had to write a separate method for my test case `InheritanceNavigationDataTests.VerifyNavigationData` where I could set up the test converter to use my `NoSourceMessageTrap`.
3. I didn't want to rewrite everything already existing in `NavigationDataTests`; that was why I moved most of the common stuff to a new fixture `NavigationDataFixture`.
4. The file NavigationDataTests.cs is pretty cluttered now and violates the one-class-per-file rule in nUnit coding standard. The point is that I don't know which classes should be moved to their own files(; they all seem to me pretty closely related).

Now for the solution, I found that `Microsoft.VisualStudio.TestPlatform.ObjectModel.DiaSession.GetNavigationData` was unable to retrieve navigation data if the provided method was defined in a base class of the given class( rather than being defined in the given class itself). It's probably a limitation in `DiaSession.GetNavigationData` behaviour, but we can make up for that by looking up the real class containing the method definition and providing its name to `DiaSession.GetNavigationData`.

I found that `AsyncMethodHelper.GetClassNameForAsyncMethod`, that's called just a few lines below `DiaSession.GetNavigationData`, has most of the code needed to accomplish this lookup so I moved this code outside `AsyncMethodHelper.GetClassNameForAsyncMethod` to `TestConverter.GetNavigationData`. This would prevent duplicating the declaring class lookup effort at run time. I modified `AsyncMethodHelper.GetClassNameForAsyncMethod` to take the lookup result directly and pick up from there. I removed a couple of(now unneeded) methods and fields from `AsyncMethodHelper`.

I appreciate it if someone can look at this PR and help me get it into good shape.

On a side note, I had some problems to make my new test succeed as the development package Microsoft.VisualStudio.TestPlatform.ObjectModel from NUnit MyGet Feed doesn't contain all the needed assemblies. A complete break down of this problem can be found in #164(; the PR itself is now obsolete). I had to replace dependencies on this assembly with the ones shipping with my version of visual studio(2015 in my case). I might later open a separate issue for this problem(affecting only the development environment).