### PR TITLE
Fix navigation data retrieval for methods defined in a base class

### DIFF
--- a/demo/NUnitTestDemo/InheritedTestTests.cs
+++ b/demo/NUnitTestDemo/InheritedTestTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace NUnitTestDemo
+{
+    public abstract class InheritedTestBaseClass
+    {
+        [Test]
+        public void TestInBaseClass()
+        {
+        }
+    }
+
+    public class InheritedTestDerivedClass : InheritedTestBaseClass
+    {
+    }
+}

--- a/demo/NUnitTestDemo/NUnit3TestDemo.csproj
+++ b/demo/NUnitTestDemo/NUnit3TestDemo.csproj
@@ -51,6 +51,7 @@
     <Compile Include="ConfigFileTests.cs" />
     <Compile Include="ExpectedOutcomeAttributes.cs" />
     <Compile Include="GenericTests.cs" />
+    <Compile Include="InheritedTestTests.cs" />
     <Compile Include="TextOutputTests.cs" />
     <Compile Include="ParameterizedTests.cs" />
     <Compile Include="SetUpFixtureTests.cs" />

--- a/src/NUnitTestAdapter/Internal/NavigationDataHelper.cs
+++ b/src/NUnitTestAdapter/Internal/NavigationDataHelper.cs
@@ -8,13 +8,27 @@ using System.Reflection;
 
 namespace NUnit.VisualStudio.TestAdapter.Internal
 {
-    public class AsyncMethodHelper : MarshalByRefObject
+    public class NavigationDataHelper : MarshalByRefObject
     {
         Assembly targetAssembly;
 
         public void LoadAssembly(string assemblyName)
         {
             targetAssembly = Assembly.LoadFrom(assemblyName);
+        }
+
+        public string GetDefiningClassName(string className, string methodName)
+        {
+            var type = targetAssembly.GetType(className);
+
+            if (type != null)
+            {
+                var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                if (method != null)
+                    return method.DeclaringType.FullName;
+            }
+
+            return className;
         }
 
         public string GetClassNameForAsyncMethod(string className, string methodName)

--- a/src/NUnitTestAdapter/Internal/NavigationDataHelper.cs
+++ b/src/NUnitTestAdapter/Internal/NavigationDataHelper.cs
@@ -23,7 +23,7 @@ namespace NUnit.VisualStudio.TestAdapter.Internal
 
             if (type != null)
             {
-                var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                var method = type.GetMethods().Where(o => o.Name == methodName).OrderBy(o => o.GetParameters().Length).FirstOrDefault();
                 if (method != null)
                     return method.DeclaringType.FullName;
             }

--- a/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit3TestAdapter.csproj
@@ -76,7 +76,7 @@
   <ItemGroup>
     <Compile Include="AdapterSettings.cs" />
     <Compile Include="NUnitEventListener.cs" />
-    <Compile Include="Internal\AsyncMethodHelper.cs" />
+    <Compile Include="Internal\NavigationDataHelper.cs" />
     <Compile Include="Internal\Stackframe.cs" />
     <Compile Include="Internal\StackframeParser.cs" />
     <Compile Include="Internal\Stacktrace.cs" />

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -143,7 +143,7 @@ namespace NUnit.VisualStudio.TestAdapter
             var className = testNode.GetAttribute("classname");
             var methodName = testNode.GetAttribute("methodname");
             var navData = GetNavigationData(className, methodName);
-            if (navData != null)
+            if (NavigationDataIsValid(navData))
             {
                 testCase.CodeFilePath = navData.FileName;
                 testCase.LineNumber = navData.MinLineNumber;
@@ -162,7 +162,7 @@ namespace NUnit.VisualStudio.TestAdapter
             // First try using the class and method names provided directly
             var navData = DiaSession.GetNavigationData(className, methodName);
 
-            if (navData != null && navData.FileName != null) return navData;
+            if (NavigationDataIsValid(navData)) return navData;
 
             // We only use NavigationDataHelper if the normal call to DiaSession fails
             // because it causes creation of a separate AppDomain for reflection.
@@ -172,7 +172,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 if (definingClassName != className)
                 {
                     navData = DiaSession.GetNavigationData(definingClassName, methodName);
-                    if (navData != null && navData.FileName != null)
+                    if (NavigationDataIsValid(navData))
                         return navData;
                 }
 
@@ -181,10 +181,15 @@ namespace NUnit.VisualStudio.TestAdapter
                     navData = diaSession.GetNavigationData(stateMachineClassName, "MoveNext");
             }
 
-            if (navData == null || navData.FileName == null)
+            if (!NavigationDataIsValid(navData))
                 logger.Warning(string.Format("No source data found for {0}.{1}", className, methodName));
 
             return navData;
+        }
+
+        private static bool NavigationDataIsValid(DiaNavigationData navData)
+        {
+            return navData != null && navData.FileName != null;
         }
 
         // Public for testing

--- a/src/NUnitTestAdapterTests/NavigationDataTests.cs
+++ b/src/NUnitTestAdapterTests/NavigationDataTests.cs
@@ -47,6 +47,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [TestCase("+GenericFixture`2", "Matches", 116, 117, 117, 118)]
         [TestCase("+GenericFixture`2+DoublyNested", "WriteBoth", 132, 133, 134, 134)]
         [TestCase("+GenericFixture`2+DoublyNested`1", "WriteAllThree", 151, 152, 153, 153)]
+        [TestCase("+DerivedClass", "EmptyMethod_ThreeLines", 160, 161, 161, 161)]
         public void VerifyNavigationData(string suffix, string methodName, int minLineDebug, int minLineRelease, int maxLineRelease, int maxLineDebug)
         {
             // Get the navigation data - ensure names are spelled correctly!

--- a/src/NUnitTestAdapterTests/NavigationTestData.cs
+++ b/src/NUnitTestAdapterTests/NavigationTestData.cs
@@ -161,7 +161,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             } // maxLineDebug = minLineRelease = maxLineRelease = 161
         }
 
-        public class DerivedClass
+        public class DerivedClass : BaseClass
         {
         }
     }

--- a/src/NUnitTestAdapterTests/NavigationTestData.cs
+++ b/src/NUnitTestAdapterTests/NavigationTestData.cs
@@ -156,7 +156,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 
         public abstract class BaseClass
         {
-            public void EmptyMethodThreeLines()
+            public void EmptyMethod_ThreeLines()
             { // minLineDebug = 160
             } // maxLineDebug = minLineRelease = maxLineRelease = 161
         }

--- a/src/NUnitTestAdapterTests/NavigationTestData.cs
+++ b/src/NUnitTestAdapterTests/NavigationTestData.cs
@@ -21,7 +21,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 
 
         } // minLineRelease = maxLineDebug = maxLineRelease = 23
-        
+
         public void SimpleMethod_Void_NoArgs()
         {// minLineDebug = 26
             const int answer = 42;
@@ -91,7 +91,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             private readonly double x;
             private readonly string s;
 
-            public ParameterizedFixture(double x, string s) 
+            public ParameterizedFixture(double x, string s)
             {
                 this.x = x;
                 this.s = s;
@@ -107,7 +107,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         {
             private readonly T1 x;
 
-            public GenericFixture(T1 x) 
+            public GenericFixture(T1 x)
             {
                 this.x = x;
             }
@@ -152,6 +152,17 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                     Console.Write(X + Y.ToString() + Z); // minLineRelease = 152
                 } // maxLineDebug = maxLineRelease = 153
             }
+        }
+
+        public abstract class BaseClass
+        {
+            public void EmptyMethodThreeLines()
+            { // minLineDebug = 160
+            } // maxLineDebug = minLineRelease = maxLineRelease = 161
+        }
+
+        public class DerivedClass
+        {
         }
     }
 }


### PR DESCRIPTION
Fixes #163 

This fix can be left in even after the framework itself is fixed to return the correct declaring class name for tests defined in a base class. The new code only comes into play if the navigation data can't be retrieved in the normal way.