### PR TITLE
Set default test name pattern to old default value

### DIFF
--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -164,6 +164,9 @@ namespace NUnit.VisualStudio.TestAdapter
             package.Settings[PackageSettings.ProcessModel] = "InProcess";
             package.Settings[PackageSettings.DomainUsage] = "Single";
 
+            // Force truncation of string arguments to test cases
+            package.Settings[PackageSettings.DefaultTestNamePattern] = "{m}{a:40}";
+
             // Set the work directory to the assembly location unless a setting is provided
             var workDir = Settings.WorkDirectory;
             if (workDir == null)

--- a/src/NUnitTestAdapter/PackageSettings.cs
+++ b/src/NUnitTestAdapter/PackageSettings.cs
@@ -193,6 +193,11 @@ namespace NUnit.Common
         /// </summary>
         public const string SynchronousEvents = "SynchronousEvents";
 
+        /// <summary>
+        /// Set default pattern used to generate test case names
+        /// </summary>
+        public const string DefaultTestNamePattern = "DefaultTestNamePattern";
+
         #endregion
 
         #region Internal Settings - Used only within the engine


### PR DESCRIPTION
This PR deals with change in the default NUnit test name pattern by explicitly setting its own default.

The 19 Appveyor errors on the branch are due to the fact that this branch doesn't yet have some unrelated changes that exist in master.