### PR TITLE
Display immediate text output from tests

### DIFF
--- a/demo/NUnitTestDemo/TextOutputTests.cs
+++ b/demo/NUnitTestDemo/TextOutputTests.cs
@@ -19,8 +19,36 @@ namespace NUnitTestDemo
         [Test]
         public void WriteToError()
         {
-            Console.Error.Write("This is Error line 1");
-            Console.Error.Write("This is Error line 2\nThis is Error line 3");
+            Console.Error.WriteLine("This is Error line 1");
+            Console.Error.WriteLine("This is Error line 2\nThis is Error line 3");
+        }
+
+        [Test]
+        public void WriteToTestContext()
+        {
+            TestContext.WriteLine("Line 1 to TestContext");
+            TestContext.WriteLine("Line 2 to TestContext\nLine 3 to TestContext");
+        }
+
+        [Test]
+        public void WriteToTestContextOut()
+        {
+            TestContext.Out.WriteLine("Line 1 to TestContext.Out");
+            TestContext.Out.WriteLine("Line 2 to TestContext.Out\nLine 3 to TestContext.Out");
+        }
+
+        [Test]
+        public void WriteToTestContextError()
+        {
+            TestContext.Error.WriteLine("Line 1 to TestContext.Error");
+            TestContext.Error.WriteLine("Line 2 to TestContext.Error\nLine 3 to TestContext.Error");
+        }
+
+        [Test]
+        public void WriteToTestContextProgress()
+        {
+            TestContext.Progress.WriteLine("Line 1 to TestContext.Progress");
+            TestContext.Progress.WriteLine("Line 2 to TestContext.Progress\nLine 3 to TestContext.Progress");
         }
 
         [Test]

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -58,6 +58,10 @@ namespace NUnit.VisualStudio.TestAdapter
                     case "test-suite":
                         SuiteFinished(node);
                         break;
+
+                    case "test-output":
+                        TestOutput(node);
+                        break;
                 }
             }
             catch(Exception ex)
@@ -137,6 +141,23 @@ namespace NUnit.VisualStudio.TestAdapter
                         _recorder.SendMessage(TestMessageLevel.Error, stackNode.InnerText);
                 }
             }
+        }
+
+        private static readonly string NL = Environment.NewLine;
+        private static readonly int NL_LENGTH = NL.Length;
+
+        public void TestOutput(XmlNode outputNode)
+        {
+            var testName = outputNode.GetAttribute("testname");
+            var stream = outputNode.GetAttribute("stream");
+            var text = outputNode.InnerText;
+            var level = stream == "Error" ? TestMessageLevel.Error : TestMessageLevel.Informational;
+
+            // Remove final newline since logger will add one
+            if (text.EndsWith(NL))
+                text = text.Substring(0, text.Length - NL_LENGTH);
+
+            _recorder.SendMessage(level, text);
         }
     }
 }


### PR DESCRIPTION
Fixes #132 

Immediate text output means output created using
 * Console.Error
 * TestContext.Error
 * TestContext.Progress
These are displayed in the output window. Note that due to the limitations of the Output Window logger, individual Writes are displayed on a separate line. Essentially, there is no difference between Write and WriteLine when used with the adapter.

The following are unchanged and go to the normal test output
 * Console.Write/Writeline
 * Console.Out
 * TestContext.Write/WriteLine
 * TestContext.Out