### PR TITLE
Save and restore random seed

### DIFF
--- a/demo/NUnitTestDemo/ParameterizedTests.cs
+++ b/demo/NUnitTestDemo/ParameterizedTests.cs
@@ -96,6 +96,11 @@ namespace NUnitTestDemo
         {
         }
 
+        [Test]
+        public void TestCaseWithRandomParameter([Random(1)] int x)
+        {
+        }
+
 #if false // Test for issue #144
         [MyTestCase]
         public void TestCaseWithBadTestBuilder(string baz)

--- a/demo/demo.runsettings
+++ b/demo/demo.runsettings
@@ -28,6 +28,7 @@
     <DefaultTimeout>5000</DefaultTimeout>
     <WorkDirectory>work</WorkDirectory>
     <InternalTraceLevel>Info</InternalTraceLevel>
+    <RandomSeed>1234567</RandomSeed>
   </NUnit>-->
 
 </RunSettings>

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -41,6 +41,8 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 TestLog.Debug("Processing " + sourceAssembly);
 
+                Settings.SaveRandomSeed(Path.GetDirectoryName(sourceAssembly));
+
                 ITestRunner runner = null;
 
                 runner = GetRunnerFor(sourceAssembly);

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -41,7 +41,11 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 TestLog.Debug("Processing " + sourceAssembly);
 
-                Settings.SaveRandomSeed(Path.GetDirectoryName(sourceAssembly));
+                // Only save if seed is not specified in runsettings
+                // This allows workaround in case there is no valid
+                // location in which the seed may be saved.
+                if (!Settings.RandomSeedSpecified)
+                    Settings.SaveRandomSeed(Path.GetDirectoryName(sourceAssembly));
 
                 ITestRunner runner = null;
 

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -175,6 +175,9 @@ namespace NUnit.VisualStudio.TestAdapter
             if (!Debugger.IsAttached)
                 Debugger.Launch();
 #endif
+
+            Settings.RestoreRandomSeed(Path.GetDirectoryName(assemblyName));
+
             _activeRunner = GetRunnerFor(assemblyName);
 
             try

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -176,7 +176,9 @@ namespace NUnit.VisualStudio.TestAdapter
                 Debugger.Launch();
 #endif
 
-            Settings.RestoreRandomSeed(Path.GetDirectoryName(assemblyName));
+            // No need to restore if the seed was in runsettings file
+            if (!Settings.RandomSeedSpecified)
+                Settings.RestoreRandomSeed(Path.GetDirectoryName(assemblyName));
 
             _activeRunner = GetRunnerFor(assemblyName);
 

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -45,7 +45,6 @@ namespace NUnit.VisualStudio.TestAdapter
         public NUnitTestAdapter()
         {
             AdapterVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            Settings = new AdapterSettings();
         }
 
         #endregion
@@ -94,11 +93,13 @@ namespace NUnit.VisualStudio.TestAdapter
         protected void Initialize(IDiscoveryContext context, IMessageLogger messageLogger)
         {
             TestEngine = new TestEngineClass();
-            TestLog = new TestLogger(messageLogger, Settings.Verbosity);
+            TestLog = new TestLogger(messageLogger);
+            Settings = new AdapterSettings(TestLog);
 
             try
             {
                 Settings.Load(context);
+                TestLog.Verbosity = Settings.Verbosity;
             }
             catch (Exception e)
             {

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -89,8 +89,8 @@ namespace NUnit.VisualStudio.TestAdapter
 
         // The Adapter is constructed using the default constructor.
         // We don't have any info to initialize it until one of the
-        // ITestDiscovery or ITestExecutor methods is called. The
-        // each Discover or Execute method must call this method.
+        // ITestDiscovery or ITestExecutor methods is called. Each 
+        // Discover or Execute method must call this method.
         protected void Initialize(IDiscoveryContext context, IMessageLogger messageLogger)
         {
             TestEngine = new TestEngineClass();
@@ -158,7 +158,7 @@ namespace NUnit.VisualStudio.TestAdapter
             if (Settings.PrivateBinPath != null)
                 package.Settings[PackageSettings.PrivateBinPath] = Settings.PrivateBinPath;
 
-            if (Settings.RandomSeed != -1)
+            if (Settings.RandomSeed.HasValue)
                 package.Settings[PackageSettings.RandomSeed] = Settings.RandomSeed;
 
             if (Settings.TestProperties.Count > 0)

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -23,7 +23,9 @@ namespace NUnit.VisualStudio.TestAdapter
 
         private IMessageLogger MessageLogger { get; set; }
 
-        private int Verbosity { get; set; }
+        public int Verbosity { get; set; }
+
+        public TestLogger(IMessageLogger messageLogger) : this(messageLogger, 0) { }
 
         public TestLogger(IMessageLogger messageLogger, int verbosity)
         {

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -55,7 +55,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.False(_settings.UseVsKeepEngineRunning);
             Assert.Null(_settings.BasePath);
             Assert.Null(_settings.PrivateBinPath);
-            Assert.That(_settings.RandomSeed, Is.EqualTo(-1));
+            Assert.NotNull(_settings.RandomSeed);
         }
 
         [Test]

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -15,7 +15,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [SetUp]
         public void SetUp()
         {
-            _settings = new AdapterSettings();
+            _settings = new AdapterSettings(null);
         }
 
         [Test]


### PR DESCRIPTION
Fixes #97 

This fix saves the initial random seed to a file upon discovery and reads it back on execution. Since there is no known writable directory other than the output directory for each assembly, it repeats the action for each assembly.  This has the benefit of simplifying the code and also allowing for variation between assemblies in the future.