### PR TITLE
Just warn upon trying to restore random seed.

### DIFF
--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -168,7 +168,7 @@ namespace NUnit.VisualStudio.TestAdapter
             }
             catch(Exception ex)
             {
-                _logger.Error("Unable to restore random seed.", ex);
+                _logger.Warning("Unable to restore random seed.", ex);
             }
             finally
             {


### PR DESCRIPTION
I had an issue with failures to restore the random seed where the test run always failed although all tests passed.