### PR TITLE
Replace error log messages with warnings in most cases

### DIFF
--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -149,7 +149,7 @@ namespace NUnit.VisualStudio.TestAdapter
             }
             catch(Exception ex)
             {
-                _logger.Error("Failed to save random seed.", ex);
+                _logger.Warning("Failed to save random seed.", ex);
             }
             finally
             {
@@ -168,7 +168,7 @@ namespace NUnit.VisualStudio.TestAdapter
             }
             catch(Exception ex)
             {
-                _logger.Error("Unable to restore random seed.", ex);
+                _logger.Warning("Unable to restore random seed.", ex);
             }
             finally
             {

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -97,11 +97,11 @@ namespace NUnit.VisualStudio.TestAdapter
                     if (ex.TypeName == "NUnit.Framework.Api.FrameworkController")
                         TestLog.Warning("   Skipping NUnit 2.x test assembly");
                     else
-                        TestLog.Error("Exception thrown discovering tests in " + sourceAssembly, ex);
+                        TestLog.Warning("Exception thrown discovering tests in " + sourceAssembly, ex);
                 }
                 catch (Exception ex)
                 {
-                    TestLog.Error("Exception thrown discovering tests in " + sourceAssembly, ex);
+                    TestLog.Warning("Exception thrown discovering tests in " + sourceAssembly, ex);
                 }
                 finally
                 {
@@ -140,7 +140,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 }
                 catch (Exception ex)
                 {
-                    TestLog.Error("Exception converting " + testNode.GetAttribute("fullname"), ex);
+                    TestLog.Warning("Exception converting " + testNode.GetAttribute("fullname"), ex);
                 }
             }
 

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -77,7 +77,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 {
                     if (ex is TargetInvocationException)
                         ex = ex.InnerException;
-                    TestLog.Error("Exception thrown executing tests", ex);
+                    TestLog.Warning("Exception thrown executing tests", ex);
                 }
             }
 
@@ -249,7 +249,7 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 if (ex is TargetInvocationException)
                     ex = ex.InnerException;
-                TestLog.Error("Exception thrown executing tests in " + assemblyName, ex);
+                TestLog.Warning("Exception thrown executing tests in " + assemblyName, ex);
             }
 
             _activeRunner.Dispose();

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -66,9 +66,9 @@ namespace NUnit.VisualStudio.TestAdapter
             }
             catch(Exception ex)
             {
-                _recorder.SendMessage(TestMessageLevel.Error,
+                _recorder.SendMessage(TestMessageLevel.Warning,
                     string.Format("Error processing {0} event for {1}", node.Name, node.GetAttribute("fullname")));
-                _recorder.SendMessage(TestMessageLevel.Error, ex.ToString());
+                _recorder.SendMessage(TestMessageLevel.Warning, ex.ToString());
             }
         }
 
@@ -129,16 +129,16 @@ namespace NUnit.VisualStudio.TestAdapter
                 if (site == "SetUp" || site == "TearDown")
                 {
                     _recorder.SendMessage(
-                        TestMessageLevel.Error,
+                        TestMessageLevel.Warning,
                         string.Format("{0} failed for test fixture {1}", site, resultNode.GetAttribute("fullname")));
 
                     var messageNode = resultNode.SelectSingleNode("failure/message");
                     if (messageNode != null)
-                        _recorder.SendMessage(TestMessageLevel.Error, messageNode.InnerText);
+                        _recorder.SendMessage(TestMessageLevel.Warning, messageNode.InnerText);
 
                     var stackNode = resultNode.SelectSingleNode("failure/stack-trace");
                     if (stackNode != null)
-                        _recorder.SendMessage(TestMessageLevel.Error, stackNode.InnerText);
+                        _recorder.SendMessage(TestMessageLevel.Warning, stackNode.InnerText);
                 }
             }
         }
@@ -151,13 +151,12 @@ namespace NUnit.VisualStudio.TestAdapter
             var testName = outputNode.GetAttribute("testname");
             var stream = outputNode.GetAttribute("stream");
             var text = outputNode.InnerText;
-            var level = stream == "Error" ? TestMessageLevel.Error : TestMessageLevel.Informational;
 
             // Remove final newline since logger will add one
             if (text.EndsWith(NL))
                 text = text.Substring(0, text.Length - NL_LENGTH);
 
-            _recorder.SendMessage(level, text);
+            _recorder.SendMessage(TestMessageLevel.Warning, text);
         }
     }
 }

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -103,8 +103,8 @@ namespace NUnit.VisualStudio.TestAdapter
             }
             catch (Exception e)
             {
-                TestLog.Error("Error initializing RunSettings. Default settings will be used");
-                TestLog.Error(e.ToString());
+                TestLog.Warning("Error initializing RunSettings. Default settings will be used");
+                TestLog.Warning(e.ToString());
             }
         }
 

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -60,7 +60,7 @@ namespace NUnit.VisualStudio.TestAdapter
             if (_vsTestCaseMap.ContainsKey(id))
                 return _vsTestCaseMap[id];
 
-            _logger.Error("Test " + id + " not found in cache");
+            _logger.Warning("Test " + id + " not found in cache");
             return null;
         }
 

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -42,18 +42,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public void Error(string message, Exception ex)
         {
-            switch (Verbosity)
-            {
-                case 0:
-                    Type type = ex.GetType();
-                    Error(string.Format(EXCEPTION_FORMAT, type, message));
-                    Error(ex.Message);
-                    break;
-                default:
-                    Error(message);
-                    Error(ex.ToString());
-                    break;
-            }
+            SendMessage(TestMessageLevel.Error, message, ex);
         }
 
         #endregion
@@ -67,21 +56,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public void Warning(string message,Exception ex)
         {
-            switch (Verbosity)
-            {
-                case 0:
-                    var type = ex.GetType();
-                    Warning(string.Format(EXCEPTION_FORMAT, type, message));
-                    Warning(ex.Message);
-                    break;
-
-                default:
-                    Warning(message);
-                    Warning(ex.ToString());
-                    break;
-            }
-
-            SendMessage(TestMessageLevel.Warning, message);
+            SendMessage(TestMessageLevel.Warning, message, ex);
         }
 
         #endregion
@@ -106,10 +81,30 @@ namespace NUnit.VisualStudio.TestAdapter
 
         #endregion
 
+        #region SendMessage
+
         public void SendMessage(TestMessageLevel testMessageLevel, string message)
         {
             if (MessageLogger != null)
                 MessageLogger.SendMessage(testMessageLevel, message);
         }
+
+        public void SendMessage(TestMessageLevel testMessageLevel, string message, Exception ex)
+        {
+            switch (Verbosity)
+            {
+                case 0:
+                    var type = ex.GetType();
+                    SendMessage(testMessageLevel, string.Format(EXCEPTION_FORMAT, type, message));
+                    SendMessage(testMessageLevel, ex.Message);
+                    break;
+
+                default:
+                    SendMessage(testMessageLevel, message);
+                    SendMessage(testMessageLevel, ex.ToString());
+                    break;
+            }
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Fixes #239 

Basically, I replaced all error calls where we were swallowing the exception with warnings. If we want a particular error to fail a run under TFS, then that should go back to being an error. The benefit of the current change is that a run that passes under the IDE should pass under TFS and vice versa.