### PR TITLE
Make sure we don't send an empty string to VS logger

### DIFF
--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -156,6 +156,9 @@ namespace NUnit.VisualStudio.TestAdapter
             if (text.EndsWith(NL))
                 text = text.Substring(0, text.Length - NL_LENGTH);
 
+            // An empty message will cause SendMessage to throw
+            if (text.Length == 0) text = " ";
+
             _recorder.SendMessage(TestMessageLevel.Warning, text);
         }
     }


### PR DESCRIPTION
Fixes #220 which was caused by sending an empty string to the logger. We just send a single space instead.