### PR TITLE
Fix no source available for nested classes

### DIFF
--- a/src/NUnitTestAdapter/NavigationDataProvider.cs
+++ b/src/NUnitTestAdapter/NavigationDataProvider.cs
@@ -48,7 +48,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
 #if true
             TypeDefinition typeDef;
-            if (!_typeDefs.TryGetValue(className, out typeDef))
+            if (!TryGetTypeDefinition(className, out typeDef))
                 return NavigationData.Invalid;
 
             MethodDefinition methodDef = null;
@@ -110,10 +110,15 @@ namespace NUnit.VisualStudio.TestAdapter
         {
             TypeDefinition type;
 
-            if (_typeDefs.TryGetValue(StandardizeTypeName(className), out type))
+            if (TryGetTypeDefinition(className, out type))
                 return type.GetMethods();
 
             return Enumerable.Empty<MethodDefinition>();
+        }
+
+        bool TryGetTypeDefinition(string className, out TypeDefinition typeDef)
+        {
+            return _typeDefs.TryGetValue(StandardizeTypeName(className), out typeDef);
         }
 
         static SequencePoint FirstOrDefaultSequencePoint(MethodDefinition testMethod)

--- a/src/NUnitTestAdapterTests/NavigationDataTests.cs
+++ b/src/NUnitTestAdapterTests/NavigationDataTests.cs
@@ -39,6 +39,10 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [TestCase("/GenericFixture`2/DoublyNested", "WriteBoth", 132, 133)]
         [TestCase("/GenericFixture`2/DoublyNested`1", "WriteAllThree", 151, 152)]
         [TestCase("/DerivedClass", "EmptyMethod_ThreeLines", 160, 161)]
+        // Handles sub class format from Type.FullName
+        [TestCase("+NestedClass", "SimpleMethod_Void_NoArgs", 83, 85)]
+        [TestCase("+GenericFixture`2+DoublyNested", "WriteBoth", 132, 133)]
+        [TestCase("+GenericFixture`2+DoublyNested`1", "WriteAllThree", 151, 152)]
         public void VerifyNavigationData(string suffix, string methodName, int expectedLineDebug, int expectedLineRelease)
         {
             // Get the navigation data - ensure names are spelled correctly!

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -47,7 +47,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void LoadMockassembly()
         {
             // Sanity check to be sure we have the correct version of mock-assembly.dll
-            Assert.That(NUnit.Tests.Assemblies.MockAssembly.Tests, Is.EqualTo(31),
+            Assert.That(NUnit.Tests.Assemblies.MockAssembly.Tests, Is.EqualTo(34),
                 "The reference to mock-assembly.dll appears to be the wrong version");
 
             TestCases = new List<TestCase>();
@@ -76,6 +76,17 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         {
             var testCase = TestCases.Find(tc => tc.DisplayName == name);
             Assert.That(testCase.FullyQualifiedName, Is.EqualTo(fullName));
+        }
+
+        [TestCase("NestedClassTest1")] // parent
+        [TestCase("NestedClassTest2")] // child
+        [TestCase("NestedClassTest3")] // grandchild
+        public void VerifyNestedTestCaseSourceIsAvailable(string name)
+        {
+            var testCase = TestCases.Find(tc => tc.DisplayName == name);
+            
+            Assert.That(!string.IsNullOrEmpty(testCase.Source));
+            Assert.Greater(testCase.LineNumber, 0);
         }
 
         #region ITestCaseDiscoverySink Methods

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -53,7 +53,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             MockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
 
             // Sanity check to be sure we have the correct version of mock-assembly.dll
-            Assert.That(MockAssembly.Tests, Is.EqualTo(31),
+            Assert.That(MockAssembly.Tests, Is.EqualTo(34),
                 "The reference to mock-assembly.dll appears to be the wrong version");
             new List<TestCase>();
             testResults = new List<TestResult>();

--- a/src/mock-assembly/MockAssembly.cs
+++ b/src/mock-assembly/MockAssembly.cs
@@ -37,15 +37,16 @@ namespace NUnit.Tests
             public const int Classes = 9;
             public const int NamespaceSuites = 6; // assembly, NUnit, Tests, Assemblies, Singletons, TestAssembly
 
-            public const int Tests = MockTestFixture.Tests 
-                        + Singletons.OneTestCase.Tests 
-                        + TestAssembly.MockTestFixture.Tests 
+            public const int Tests = MockTestFixture.Tests
+                        + Singletons.OneTestCase.Tests
+                        + TestAssembly.MockTestFixture.Tests
                         + IgnoredFixture.Tests
                         + ExplicitFixture.Tests
                         + BadFixture.Tests
                         + FixtureWithTestCases.Tests
                         + ParameterizedFixture.Tests
-                        + GenericFixtureConstants.Tests;
+                        + GenericFixtureConstants.Tests
+                        + ParentClass.Tests;
             
             public const int Suites = MockTestFixture.Suites 
                         + Singletons.OneTestCase.Suites
@@ -293,5 +294,25 @@ namespace NUnit.Tests
         
         [Test]
         public void Test2() { }
+    }
+
+    public class ParentClass
+    {
+        public const int Tests = 3;
+
+        [Test]
+        public void NestedClassTest1() { }
+
+        public class ChildClass
+        {
+            [Test]
+            public void NestedClassTest2() { }
+
+            public class GrandChildClass
+            {
+                [Test]
+                public void NestedClassTest3() { }
+            }
+        }
     }
 }


### PR DESCRIPTION
Updated adapter to locate source file and line for tests in nested
classes.  Previously the message 'No source available' was displayed for
tests in sub classes and some Test Explorer functionality was unavailable.

Issue #218