### PR TITLE
Ensure PackageSettings.WorkDirectory is always a full path

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -68,19 +68,21 @@ namespace NUnit.VisualStudio.TestAdapter
 
             foreach (string sourceAssembly in sources)
             {
+                var sourceAssemblyPath = Path.IsPathRooted(sourceAssembly) ? sourceAssembly : Path.Combine(Directory.GetCurrentDirectory(), sourceAssembly);
+
                 TestLog.Debug("Processing " + sourceAssembly);
 
                 // Only save if seed is not specified in runsettings
                 // This allows workaround in case there is no valid
                 // location in which the seed may be saved.
                 if (!Settings.RandomSeedSpecified)
-                    Settings.SaveRandomSeed(Path.GetDirectoryName(sourceAssembly));
+                    Settings.SaveRandomSeed(Path.GetDirectoryName(sourceAssemblyPath));
 
                 ITestRunner runner = null;
 
                 try
                 {
-                    runner = GetRunnerFor(sourceAssembly);
+                    runner = GetRunnerFor(sourceAssemblyPath);
 
                     XmlNode topNode = runner.Explore(TestFilter.Empty);
 
@@ -90,7 +92,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
                     if (topNode.GetAttribute("runstate") == "Runnable")
                     {
-                        var testConverter = new TestConverter(TestLog, sourceAssembly);
+                        var testConverter = new TestConverter(TestLog, sourceAssemblyPath);
 
                         int cases = ProcessTestCases(topNode, discoverySink, testConverter);
 

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -86,15 +86,13 @@ namespace NUnit.VisualStudio.TestAdapter
                 return;
             }
 
-            foreach (var source in sources)
+            foreach (var assemblyName in sources)
             {
                 try
                 {
-                    var assemblyName = source;
-                    if (!Path.IsPathRooted(assemblyName))
-                        assemblyName = Path.Combine(Directory.GetCurrentDirectory(), assemblyName);
+                    var assemblyPath = Path.IsPathRooted(assemblyName) ? assemblyName : Path.Combine(Directory.GetCurrentDirectory(), assemblyName);
 
-                    RunAssembly(assemblyName, TestFilter.Empty);
+                    RunAssembly(assemblyPath, TestFilter.Empty);
                 }
                 catch (Exception ex)
                 {
@@ -134,10 +132,12 @@ namespace NUnit.VisualStudio.TestAdapter
                 try
                 {
                     var assemblyName = assemblyGroup.Key;
+                    var assemblyPath = Path.IsPathRooted(assemblyName) ? assemblyName : Path.Combine(Directory.GetCurrentDirectory(), assemblyName);
+
                     var filterBuilder = CreateTestFilterBuilder();
                     var filter = filterBuilder.MakeTestFilter(assemblyGroup);
 
-                    RunAssembly(assemblyName, filter);
+                    RunAssembly(assemblyPath, filter);
                 }
                 catch (Exception ex)
                 {

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -210,9 +210,9 @@ namespace NUnit.VisualStudio.TestAdapter
             // Set the work directory to the assembly location unless a setting is provided
             var workDir = Settings.WorkDirectory;
             if (workDir == null)
-                workDir = Path.GetDirectoryName(Path.GetFullPath(assemblyName));
+                workDir = Path.GetDirectoryName(assemblyName);
             else if (!Path.IsPathRooted(workDir))
-                workDir = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(assemblyName), workDir));
+                workDir = Path.Combine(Path.GetDirectoryName(assemblyName), workDir);
             if (!Directory.Exists(workDir))
                 Directory.CreateDirectory(workDir);
             package.Settings[PackageSettings.WorkDirectory] = workDir;

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -210,9 +210,9 @@ namespace NUnit.VisualStudio.TestAdapter
             // Set the work directory to the assembly location unless a setting is provided
             var workDir = Settings.WorkDirectory;
             if (workDir == null)
-                workDir = Path.GetDirectoryName(assemblyName);
+                workDir = Path.GetDirectoryName(Path.GetFullPath(assemblyName));
             else if (!Path.IsPathRooted(workDir))
-                workDir = Path.Combine(Path.GetDirectoryName(assemblyName), workDir);
+                workDir = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(assemblyName), workDir));
             if (!Directory.Exists(workDir))
                 Directory.CreateDirectory(workDir);
             package.Settings[PackageSettings.WorkDirectory] = workDir;


### PR DESCRIPTION
Fix for Issue #338.