### PR TITLE
Update copyright

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2016 Charlie Poole
+Copyright (c) 2011-2017 Charlie Poole, 2014-2017 Terje Sandstrom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/demo/NUnitTestDemo/Properties/AssemblyInfo.cs
+++ b/demo/NUnitTestDemo/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NUnitTestDemo")]
-[assembly: AssemblyCopyright("Copyright © Charlie Poole 2011-2016")]
+[assembly: AssemblyCopyright("Copyright © Charlie Poole 2011-2017, Terje Sandstrom 2014-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -4,7 +4,7 @@
         <id>NUnit3TestAdapter</id>
         <version>$version$</version>
         <title>NUnit 3 Test Adapter for Visual Studio</title>
-        <authors>Charlie Poole</authors>
+        <authors>Charlie Poole, Terje Sandstrom</authors>
         <licenseUrl>http://nunit.org/nuget/nunit3-license.txt</licenseUrl>
         <projectUrl>https://github.com/nunit/docs/wiki/VS-Adapter</projectUrl>
         <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
@@ -16,7 +16,7 @@ Note that this package ONLY contains the adapter, not the NUnit framework.  You 
 
 The package works with Visual Studio 2012 and newer.</description>
         <releaseNotes>This release works with NUnit 3.0 and higher only.</releaseNotes>
-        <copyright>Copyright (c) 2016 Charlie Poole</copyright>
+        <copyright>Copyright (c) 2011-2017 Charlie Poole, 2014-2017 Terje Sandstrom</copyright>
         <language>en-US</language>
         <tags>test visualstudio testadapter nunit nunit3</tags>
 

--- a/src/NUnit3TestAdapterInstall/Properties/AssemblyInfo.cs
+++ b/src/NUnit3TestAdapterInstall/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NUnit3TestAdapterInstall")]
-[assembly: AssemblyCopyright("Copyright © 2011-2016, Charlie Poole")]
+[assembly: AssemblyCopyright("Copyright © 2011-2017 Charlie Poole,2014-2017 Terje Sandstrom")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/NUnit3TestAdapterInstall/Properties/AssemblyInfo.cs
+++ b/src/NUnit3TestAdapterInstall/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NUnit3TestAdapterInstall")]
-[assembly: AssemblyCopyright("Copyright © 2011-2017 Charlie Poole,2014-2017 Terje Sandstrom")]
+[assembly: AssemblyCopyright("Copyright © 2011-2017 Charlie Poole, 2014-2017 Terje Sandstrom")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -18,7 +18,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>NUnitAdapter.snk</AssemblyOriginatorKeyFile>
     <PackageId>NUnit3TestAdapter</PackageId>
-    <Authors>Charlie Poole</Authors>
+    <Authors>Charlie Poole, Terje Sandstrom</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/NavigationData.cs
+++ b/src/NUnitTestAdapter/NavigationData.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2016 Charlie Poole
+// Copyright (c) 2016 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/NavigationDataProvider.cs
+++ b/src/NUnitTestAdapter/NavigationDataProvider.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2016 Charlie Poole
+// Copyright (c) 2016 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/PackageSettings.cs
+++ b/src/NUnitTestAdapter/PackageSettings.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2014 Charlie Poole
+// Copyright (c) 2014 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
+++ b/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// ****************************************************************
-// Copyright (c) 2011 Charlie Poole. All rights reserved.
+// Copyright (c) 2011 Charlie Poole, Terje Sandstrom.
 // ****************************************************************
 
 using System;
@@ -9,9 +9,9 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("NUnit 3 Test Adapter for Visual Studio")]
 [assembly: AssemblyDescription("A package including the NUnit 3 TestAdapter for Visual Studio 2012 onwards.  With this package you don't need to install the VSIX adapter package, and you don't need to upload the adapter to your TFS server.\r\n        \r\nNote that this package ONLY contains the adapter, not the NUnit framework.  You must also get the framework. You only need one such package for a solution. \r\n\r\nThe package works with Visual Studio 2012 and newer.\r\n\r\nNote that this package ONLY contains the adapter, not the NUnit framework.  You must also get the framework. You only need one such package for a solution.\r\n\r\nThe package works with Visual Studio 2012 and newer.")]
-[assembly: AssemblyCompany("NUnit Software")]
+[assembly: AssemblyCompany("NUnit Project")]
 [assembly: AssemblyProduct("NUnit3TestAdapter")]
-[assembly: AssemblyCopyright("Copyright © 2011-2017, Charlie Poole")]
+[assembly: AssemblyCopyright("Copyright © 2011-2017 Charlie Poole, 2014-2017 Terje Sandstrom")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: CLSCompliant(false)]

--- a/src/NUnitTestAdapter/StackTraceFilter.cs
+++ b/src/NUnitTestAdapter/StackTraceFilter.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2011 Charlie Poole
+// Copyright (c) 2011 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/TFSTestFilter.cs
+++ b/src/NUnitTestAdapter/TFSTestFilter.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2013 Charlie Poole
+// Copyright (c) 2013 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2013 Charlie Poole
+// Copyright (c) 2013 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/TraitsFeature.cs
+++ b/src/NUnitTestAdapter/TraitsFeature.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2013-2015 Charlie Poole
+// Copyright (c) 2013-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/XmlHelper.cs
+++ b/src/NUnitTestAdapter/XmlHelper.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2010-2014 Charlie Poole
+// Copyright (c) 2010-2014 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/AssemblyRunnerTests.cs
+++ b/src/NUnitTestAdapterTests/AssemblyRunnerTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/Fakes/FakeDiscoveryContext.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeDiscoveryContext.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2012 Charlie Poole
+// Copyright (c) 2012 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/Fakes/FakeRunContext.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeRunContext.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2012 Charlie Poole
+// Copyright (c) 2012 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/Fakes/FakeRunSettings.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeRunSettings.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2012 Charlie Poole
+// Copyright (c) 2012 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/Fakes/FakeTestData.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeTestData.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2015 Charlie Poole
+// Copyright (c) 2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/Fakes/MessageLoggerStub.cs
+++ b/src/NUnitTestAdapterTests/Fakes/MessageLoggerStub.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2015 Charlie Poole
+// Copyright (c) 2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2012-2015 Charlie Poole
+// Copyright (c) 2012-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/TestConverterTests_StaticHelpers.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests_StaticHelpers.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole
+// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2012-2015 Charlie Poole
+// Copyright (c) 2012-2015 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/empty-assembly/EmptyAssembly.cs
+++ b/src/empty-assembly/EmptyAssembly.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2016 Charlie Poole
+// Copyright (c) 2016 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/mock-assembly/MockAssembly.cs
+++ b/src/mock-assembly/MockAssembly.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2014 Charlie Poole
+// Copyright (c) 2014 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the


### PR DESCRIPTION
**Leave for @OsirisTerje or @CharliePoole to merge**

* Removes "NUnit Software" from the files
* Gives Names @OsirisTerje as co-copyright holder

@nunit/core-team As with the other adapter, this PR serves to name @OsirisTerje as the joint copyright holder for the nunit3-vs-adapter.