### PR TITLE
Add support for file attachments

### DIFF
--- a/src/NUnit3AdapterExternalTests/NUnit3AdapterExternalTests.csproj
+++ b/src/NUnit3AdapterExternalTests/NUnit3AdapterExternalTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -199,36 +199,46 @@ namespace NUnit.VisualStudio.TestAdapter
             if (outputNode != null)
                 vsResult.Messages.Add(new TestResultMessage(TestResultMessage.StandardOutCategory, outputNode.InnerText));
 
-            var attachments = resultNode.SelectNodes("attachments/attachment");
-            if (attachments.Count > 0)
-            {
-                var attachmentSet = new AttachmentSet(new Uri(NUnitTestAdapter.ExecutorUri), "Attachments");
+            var attachmentSet = ParseAttachments(resultNode);
+            if (attachmentSet.Attachments.Count > 0)
                 vsResult.Attachments.Add(attachmentSet);
 
-                foreach (XmlNode attachment in attachments)
-                {
-                    var path = attachment.SelectSingleNode("filePath")?.InnerText ?? string.Empty;
-                    var description = attachment.SelectSingleNode("description")?.InnerText;
+            return vsResult;
+        }
 
-                    try
-                    {
-                        // We only support absolute paths since we dont lookup working directory here
-                        // any problem with path will throw an exception
-                        var fileUri = new Uri(path, UriKind.Absolute);
-                        attachmentSet.Attachments.Add(new UriDataAttachment(fileUri, description));
-                    }
-                    catch (UriFormatException ex)
-                    {
-                        _logger.Warning(string.Format("Ignoring attachment with path '{0}' due to problem with path: {1}", path, ex.Message));
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.Warning(string.Format("Ignoring attachment with path '{0}': {1}.", path, ex.Message));
-                    }
+        /// <summary>
+        /// Looks for attachments in a results node and if any attachments are found they
+        /// are added to <paramref name="vsResult"/>
+        /// </summary>
+        /// <param name="resultNode">xml node for test result</param>
+        /// <returns>attachments to be added to the test, it will be empty if no attachments are found</returns>
+        private AttachmentSet ParseAttachments(XmlNode resultNode)
+        {
+            var attachmentSet = new AttachmentSet(new Uri(NUnitTestAdapter.ExecutorUri), "Attachments");
+
+            foreach (XmlNode attachment in resultNode.SelectNodes("attachments/attachment"))
+            {
+                var path = attachment.SelectSingleNode("filePath")?.InnerText ?? string.Empty;
+                var description = attachment.SelectSingleNode("description")?.InnerText;
+
+                try
+                {
+                    // We only support absolute paths since we dont lookup working directory here
+                    // any problem with path will throw an exception
+                    var fileUri = new Uri(path, UriKind.Absolute);
+                    attachmentSet.Attachments.Add(new UriDataAttachment(fileUri, description));
+                }
+                catch (UriFormatException ex)
+                {
+                    _logger.Warning($"Ignoring attachment with path '{path}' due to problem with path: {ex.Message}");
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning($"Ignoring attachment with path '{path}': {ex.Message}.");
                 }
             }
 
-            return vsResult;
+            return attachmentSet;
         }
 
         // Public for testing

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnitLite" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnitLite" Version="3.7.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void LoadMockassembly()
         {
             // Sanity check to be sure we have the correct version of mock-assembly.dll
-            Assert.That(NUnit.Tests.Assemblies.MockAssembly.Tests, Is.EqualTo(34),
+            Assert.That(NUnit.Tests.Assemblies.MockAssembly.TestsAtRuntime, Is.EqualTo(NUnit.Tests.Assemblies.MockAssembly.Tests),
                 "The reference to mock-assembly.dll appears to be the wrong version");
 
             TestCases = new List<TestCase>();

--- a/src/empty-assembly/empty-assembly.csproj
+++ b/src/empty-assembly/empty-assembly.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
   </ItemGroup>
 </Project>

--- a/src/mock-assembly/MockAssembly.cs
+++ b/src/mock-assembly/MockAssembly.cs
@@ -325,39 +325,21 @@ namespace NUnit.Tests
     [TestFixture]
     public class FixtureWithAttachment
     {
-        public const int Tests = 2;
+        public const int Tests = 1;
 
-        public static readonly string Attachment1Name = "attachment1.txt";
-        public static readonly string Attachment1Contents = "CONTENTS";
-        public static readonly string Attachment1Description = "A description with some <values>";
+        public static readonly string Attachment1Name = "mock-assembly.dll";
+        public static readonly string Attachment1Description = "A description with some <values> including & special characters";
 
-        public static readonly string Attachment2Name = "attachment2.txt";
-        public static readonly string Attachment2Contents = "CONTENTS2";
-        public static readonly string Attachment2Description = "second description";
+        public static readonly string Attachment2Name = "empty-assembly.dll";
+        public static readonly string Attachment2Description = null;
 
         [Test]
-        public void SingleAttachmentTest()
+        public void AttachmentTest()
         {
-            var context = TestContext.CurrentContext;
-            var filepath = Path.Combine(context.WorkDirectory, Attachment1Name);
-
-            File.WriteAllText(filepath, Attachment1Contents);
-            TestContext.AddTestAttachment(filepath, Attachment1Description);
-        }
-
-        [Test]
-        public void MultiAttachmentTest()
-        {
-            var context = TestContext.CurrentContext;
-            var filepath1 = Path.Combine(context.WorkDirectory, Attachment1Name);
-            var filepath2 = Path.Combine(context.WorkDirectory, Attachment2Name);
-
-            File.WriteAllText(filepath1, Attachment1Contents);
+            var filepath1 = Path.Combine(TestContext.CurrentContext.WorkDirectory, Attachment1Name);
+            var filepath2 = Path.Combine(TestContext.CurrentContext.WorkDirectory, Attachment2Name);
             TestContext.AddTestAttachment(filepath1, Attachment1Description);
-
-            File.WriteAllText(filepath2, Attachment2Contents);
             TestContext.AddTestAttachment(filepath2, Attachment2Description);
         }
     }
-
 }

--- a/src/mock-assembly/MockAssembly.cs
+++ b/src/mock-assembly/MockAssembly.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.IO;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 
@@ -34,9 +35,13 @@ namespace NUnit.Tests
         /// </summary>
         public class MockAssembly
         {
-            public const int Classes = 9;
+            public const int Classes = 10;
             public const int NamespaceSuites = 6; // assembly, NUnit, Tests, Assemblies, Singletons, TestAssembly
 
+            // While const values are copied to other projects at compile time, 
+            // readonly are taken from assembly loaded at runtime
+            // We can check the difference to see if value has changed since compilation
+            public static readonly int TestsAtRuntime = Tests;
             public const int Tests = MockTestFixture.Tests
                         + Singletons.OneTestCase.Tests
                         + TestAssembly.MockTestFixture.Tests
@@ -46,8 +51,9 @@ namespace NUnit.Tests
                         + FixtureWithTestCases.Tests
                         + ParameterizedFixture.Tests
                         + GenericFixtureConstants.Tests
-                        + ParentClass.Tests;
-            
+                        + ParentClass.Tests
+                        + FixtureWithAttachment.Tests;
+
             public const int Suites = MockTestFixture.Suites 
                         + Singletons.OneTestCase.Suites
                         + TestAssembly.MockTestFixture.Suites 
@@ -315,4 +321,43 @@ namespace NUnit.Tests
             }
         }
     }
+
+    [TestFixture]
+    public class FixtureWithAttachment
+    {
+        public const int Tests = 2;
+
+        public static readonly string Attachment1Name = "attachment1.txt";
+        public static readonly string Attachment1Contents = "CONTENTS";
+        public static readonly string Attachment1Description = "A description with some <values>";
+
+        public static readonly string Attachment2Name = "attachment2.txt";
+        public static readonly string Attachment2Contents = "CONTENTS2";
+        public static readonly string Attachment2Description = "second description";
+
+        [Test]
+        public void SingleAttachmentTest()
+        {
+            var context = TestContext.CurrentContext;
+            var filepath = Path.Combine(context.WorkDirectory, Attachment1Name);
+
+            File.WriteAllText(filepath, Attachment1Contents);
+            TestContext.AddTestAttachment(filepath, Attachment1Description);
+        }
+
+        [Test]
+        public void MultiAttachmentTest()
+        {
+            var context = TestContext.CurrentContext;
+            var filepath1 = Path.Combine(context.WorkDirectory, Attachment1Name);
+            var filepath2 = Path.Combine(context.WorkDirectory, Attachment2Name);
+
+            File.WriteAllText(filepath1, Attachment1Contents);
+            TestContext.AddTestAttachment(filepath1, Attachment1Description);
+
+            File.WriteAllText(filepath2, Attachment2Contents);
+            TestContext.AddTestAttachment(filepath2, Attachment2Description);
+        }
+    }
+
 }

--- a/src/mock-assembly/mock-assembly.csproj
+++ b/src/mock-assembly/mock-assembly.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Update nunit version to 3.7.1 for tests
* Add tests for 1 and 2 attachments
* Improve test resilency to changes so that we don't have to update
  test count att multiple locations
* Replace broken test ExplicitTestDoesNotShowUpInResults (which did not work)
  with an extra testcase for TestResultIsReportedCorrectly

Should hopefully solve #332 


### Summary of review comments 

- [x] Update code to C#7 (nameof and string interpolation)
- [x] Update remaining tests to nuget 3.7.1
- [x] Move attachment xml parsing into a separate method
- [x] Remove redundant code in TestExecutionTests
   * new List
   * typecast
- [x] Change asserts to fluent syntax
- [x] Don't create files when running tests
- [ ] Add some additional tests (as unit tests using raw xml)
  I guess these will live in TestConverterTests
     * xml with empty/no description
     * failure/warning paths (bad & missing paths)
     * Probably move one of the mock tests and make into unit test