### PR TITLE
Added DefaultTestNamePattern to runsetting section for NUnit.  #358

### DIFF
--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -1,11 +1,30 @@
+// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole, Terje Sandstrom
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Xml;
-using System.Xml.Serialization;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace NUnit.VisualStudio.TestAdapter
@@ -75,6 +94,11 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public string DomainUsage { get; set; }
 
+        /// <summary>
+        ///  Syntax documentation <see cref="https://github.com/nunit/docs/wiki/Template-Based-Test-Naming"/>
+        /// </summary>
+        public string DefaultTestNamePattern { get; set; }
+
         #endregion
 
         #region Public Methods
@@ -128,7 +152,7 @@ namespace NUnit.VisualStudio.TestAdapter
             RandomSeedSpecified = RandomSeed.HasValue;
             if (!RandomSeedSpecified)
                 RandomSeed = new Random().Next();
-
+            DefaultTestNamePattern = GetInnerText(nunitNode,"DefaultTestNamePattern");
 #if SUPPORT_REGISTRY_SETTINGS
             // Legacy (CTP) registry settings override defaults
             var registry = RegistryCurrentUser.OpenRegistryCurrentUser(@"Software\nunit.org\VSAdapter");

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -141,7 +141,7 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 return TestEngine.GetRunner(package);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 TestLog.Error("Error: Unable to get runner for this assembly. Check installation, including any extensions.");
                 TestLog.Error(ex.GetType().Name + ": " + ex.Message);
@@ -203,9 +203,15 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 package.Settings[PackageSettings.DomainUsage] = "Single";
             }
-
-            // Force truncation of string arguments to test cases
-            package.Settings[PackageSettings.DefaultTestNamePattern] = "{m}{a:40}";
+            if (Settings.DefaultTestNamePattern != null)
+            {
+                package.Settings[PackageSettings.DefaultTestNamePattern] = Settings.DefaultTestNamePattern;
+            }
+            else
+            {
+                // Force truncation of string arguments to test cases
+                package.Settings[PackageSettings.DefaultTestNamePattern] = "{m}{a:40}";
+            }
 
             // Set the work directory to the assembly location unless a setting is provided
             var workDir = Settings.WorkDirectory;

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -210,7 +210,7 @@ namespace NUnit.VisualStudio.TestAdapter
             else
             {
                 // Force truncation of string arguments to test cases
-                package.Settings[PackageSettings.DefaultTestNamePattern] = "{m}{a:40}";
+                package.Settings[PackageSettings.DefaultTestNamePattern] = "{m}{a}";
             }
 
             // Set the work directory to the assembly location unless a setting is provided

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -174,6 +174,13 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         }
 
         [Test]
+        public void DefaultTestNamePattern()
+        {
+            _settings.Load("<RunSettings><NUnit><DefaultTestNamePattern>{m}{a:1000}</DefaultTestNamePattern></NUnit></RunSettings>");
+            Assert.That(_settings.DefaultTestNamePattern,Is.EqualTo("{m}{a:1000}"));
+        }
+
+        [Test]
         public void InProcDataCollector()
         {
             _settings.Load(@"


### PR DESCRIPTION
Adding DefaultTestNamePatterns to the runsettings nunit section, so that format of test method names , including truncation of length of arguments, can be controlled by the user.  