### PR TITLE
Verbosity improvement for adapter settings  #397

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-//#define LAUNCHDEBUGGER
+// #define LAUNCHDEBUGGER
 
 using System;
 using System.IO;

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -116,11 +116,17 @@ namespace NUnit.VisualStudio.TestAdapter
                     var type = ex.GetType();
                     SendMessage(testMessageLevel, string.Format(EXCEPTION_FORMAT, type, message));
                     SendMessage(testMessageLevel, ex.Message);
+                    SendMessage(testMessageLevel,ex.StackTrace);
+                    if (ex.InnerException != null)
+                    {
+                        SendMessage(testMessageLevel,$"Innerexception: {ex.InnerException.ToString()}");
+                    }
                     break;
 
                 default:
                     SendMessage(testMessageLevel, message);
                     SendMessage(testMessageLevel, ex.ToString());
+                    SendMessage(testMessageLevel, ex.StackTrace);
                     break;
             }
         }


### PR DESCRIPTION
We're making changes to the usage of runsettings, and there is hard to see if they come in correct, so this PR contains updates to the visibility of the runsettings when verbosity is set higher (>=4).  
Since we're schema-checking the runsettings, this diagnostics will make it easier to see if you got the information correctly in. 

Example:
![2017-10-05_20-41-34](https://user-images.githubusercontent.com/203432/31246479-cc8383a4-aa0d-11e7-8456-880b864acdd1.jpg)

