### PR TITLE
Dump xml

### DIFF
--- a/copynp.cmd
+++ b/copynp.cmd
@@ -1,0 +1,3 @@
+cd package
+copy NUnit3TestAdapter.%1.nupkg  c:\nuget
+cd ..

--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -29,7 +29,44 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 namespace NUnit.VisualStudio.TestAdapter
 {
-    public class AdapterSettings
+    public interface IAdapterSettings
+    {
+        int MaxCpuCount { get; }
+        string ResultsDirectory { get; }
+        string TargetPlatform { get; }
+        string TargetFrameworkVersion { get; }
+        string TestAdapterPaths { get; }
+        bool CollectSourceInformation { get; }
+        IDictionary<string, string> TestProperties { get; }
+        string InternalTraceLevel { get; }
+        string WorkDirectory { get; }
+        int DefaultTimeout { get; }
+        int NumberOfTestWorkers { get; }
+        bool ShadowCopyFiles { get; }
+        int Verbosity { get; }
+        bool UseVsKeepEngineRunning { get; }
+        string BasePath { get; }
+        string PrivateBinPath { get; }
+        int? RandomSeed { get; }
+        bool RandomSeedSpecified { get; }
+        bool InProcDataCollectorsAvailable { get; }
+        bool SynchronousEvents { get; }
+        string DomainUsage { get;  }
+        bool DumpXmlTestDiscovery { get;  }
+        bool DumpXmlTestResults { get;  }
+
+        /// <summary>
+        ///  Syntax documentation <see cref="https://github.com/nunit/docs/wiki/Template-Based-Test-Naming"/>
+        /// </summary>
+        string DefaultTestNamePattern { get;  }
+
+        void Load(IDiscoveryContext context);
+        void Load(string settingsXml);
+        void SaveRandomSeed(string dirname);
+        void RestoreRandomSeed(string dirname);
+    }
+
+    public class AdapterSettings : IAdapterSettings
     {
         private const string RANDOM_SEED_FILE = "nunit_random_seed.tmp";
         private TestLogger _logger;
@@ -92,7 +129,12 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public bool SynchronousEvents { get; private set; }
 
-        public string DomainUsage { get; set; }
+        public string DomainUsage { get; private set; }
+
+
+        public bool DumpXmlTestDiscovery { get; private set; }
+
+        public bool DumpXmlTestResults { get; private set; }
 
         /// <summary>
         ///  Syntax documentation <see cref="https://github.com/nunit/docs/wiki/Template-Based-Test-Naming"/>
@@ -123,6 +165,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
             var nunitNode = doc.SelectSingleNode("RunSettings/NUnit");
             Verbosity = GetInnerTextAsInt(nunitNode, nameof(Verbosity), 0);
+            _logger.Verbosity = Verbosity;
 
             var runConfiguration = doc.SelectSingleNode("RunSettings/RunConfiguration");
             MaxCpuCount = GetInnerTextAsInt(runConfiguration, nameof(MaxCpuCount), -1);
@@ -141,7 +184,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     TestProperties.Add(key, value);
             }
 
-        
+          // NUnit settings
             InternalTraceLevel = GetInnerTextWithLog(nunitNode, nameof(InternalTraceLevel), "Off", "Error", "Warning", "Info", "Verbose", "Debug");
             WorkDirectory = GetInnerTextWithLog(nunitNode, nameof(WorkDirectory));
             DefaultTimeout = GetInnerTextAsInt(nunitNode, nameof(DefaultTimeout), 0);
@@ -155,6 +198,12 @@ namespace NUnit.VisualStudio.TestAdapter
             if (!RandomSeedSpecified)
                 RandomSeed = new Random().Next();
             DefaultTestNamePattern = GetInnerTextWithLog(nunitNode, nameof(DefaultTestNamePattern));
+
+            DumpXmlTestDiscovery = GetInnerTextAsBool(nunitNode, nameof(DumpXmlTestDiscovery),false);
+            DumpXmlTestResults= GetInnerTextAsBool(nunitNode, nameof(DumpXmlTestResults), false);
+
+
+
 #if SUPPORT_REGISTRY_SETTINGS
             // Legacy (CTP) registry settings override defaults
             var registry = RegistryCurrentUser.OpenRegistryCurrentUser(@"Software\nunit.org\VSAdapter");

--- a/src/NUnitTestAdapter/DumpXml.cs
+++ b/src/NUnitTestAdapter/DumpXml.cs
@@ -36,6 +36,7 @@ namespace NUnit.VisualStudio.TestAdapter.Dump
     public interface IDumpXml
     {
         void AddString(string text);
+        void AddTestEvent(string text);
     }
 
     public class DumpXml : IDumpXml
@@ -94,6 +95,16 @@ namespace NUnit.VisualStudio.TestAdapter.Dump
             var res2 = Regex.Replace(res, @"[^a-zA-Z0-9]", "");
              return res2+".dump";
         }
+
+        public void AddTestEvent(string text)
+        {
+            txt.Append("<NUnitTestEvent>");
+            txt.Append(text);
+            txt.Append("</NUnitTestEvent>");
+        }
+
+
+
 
 
         public void AddString(string text)

--- a/src/NUnitTestAdapter/DumpXml.cs
+++ b/src/NUnitTestAdapter/DumpXml.cs
@@ -23,12 +23,12 @@ namespace NUnit.VisualStudio.TestAdapter.Dump
 
         public bool DirectoryExist(string path)
         {
-            return System.IO.Directory.Exists(path);
+            return Directory.Exists(path);
         }
 
         public void CreateDirectory(string path)
         {
-            System.IO.Directory.CreateDirectory(path);
+            Directory.CreateDirectory(path);
         }
     }
 
@@ -40,6 +40,9 @@ namespace NUnit.VisualStudio.TestAdapter.Dump
 
     public class DumpXml : IDumpXml
     {
+        private const string Header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
+        private const string Rootstart = "<NUnitXml>\n";
+        private const string Rootend = "\n</NUnitXml>";
         private readonly IFile file;
         private readonly string directory;
         private readonly string filename;
@@ -47,20 +50,18 @@ namespace NUnit.VisualStudio.TestAdapter.Dump
 
         public DumpXml(string path, IFile file=null)
         {
-            this.directory = Path.GetDirectoryName(path);
-            this.filename = Path.GetFileName(path);
+            directory = Path.GetDirectoryName(path);
+            filename = Path.GetFileName(path);
             this.file = file ?? new File();
             txt = new StringBuilder();
+            txt.Append(Header);
+            txt.Append(Rootstart);
         }
-
-        
-
-
-        
 
         public void Dump2File(string path)
         {
             EnsurePathExist(path);
+            txt.Append(Rootend);
             file.WriteAllText(path,txt.ToString());
             txt = new StringBuilder();
         }
@@ -107,7 +108,7 @@ namespace NUnit.VisualStudio.TestAdapter.Dump
     {
         public static string AsString(this System.Xml.XmlNode node)
         {
-            using (var swriter = new System.IO.StringWriter())
+            using (var swriter = new StringWriter())
             {
                 using (var twriter = new System.Xml.XmlTextWriter(swriter))
                 {

--- a/src/NUnitTestAdapter/DumpXml.cs
+++ b/src/NUnitTestAdapter/DumpXml.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace NUnit.VisualStudio.TestAdapter.Dump
+{
+
+    public interface IFile
+    {
+        void WriteAllText(string path, string txt);
+        bool DirectoryExist(string path);
+
+        void CreateDirectory(string path);
+    }
+
+    public class File : IFile
+    {
+        public void WriteAllText(string path, string txt)
+        {
+            System.IO.File.WriteAllText(path,txt);
+        }
+
+        public bool DirectoryExist(string path)
+        {
+            return System.IO.Directory.Exists(path);
+        }
+
+        public void CreateDirectory(string path)
+        {
+            System.IO.Directory.CreateDirectory(path);
+        }
+    }
+
+
+    public interface IDumpXml
+    {
+        void AddString(string text);
+    }
+
+    public class DumpXml : IDumpXml
+    {
+        private readonly IFile file;
+        private readonly string directory;
+        private readonly string filename;
+        private StringBuilder txt;
+
+        public DumpXml(string path, IFile file=null)
+        {
+            this.directory = Path.GetDirectoryName(path);
+            this.filename = Path.GetFileName(path);
+            this.file = file ?? new File();
+            txt = new StringBuilder();
+        }
+
+        
+
+
+        
+
+        public void Dump2File(string path)
+        {
+            EnsurePathExist(path);
+            file.WriteAllText(path,txt.ToString());
+            txt = new StringBuilder();
+        }
+
+        private void EnsurePathExist(string path)
+        {
+            var folder = Path.GetDirectoryName(path);
+            if (!file.DirectoryExist(folder))
+                file.CreateDirectory(folder);
+        }
+
+        public void Dump4Discovery()
+        {
+            var dumpfolder = Path.Combine(directory, "Dump");
+            var path = Path.Combine(dumpfolder, $"D_{filename}.dump");
+            Dump2File(path);
+        }
+
+        public void Dump4Execution()
+        {
+            var dumpfolder = Path.Combine(directory, "Dump");
+            var path = Path.Combine(dumpfolder, $"E_{filename}.dump");
+            Dump2File(path);
+        }
+
+        public string RandomName()
+        {
+            var guid = Guid.NewGuid();
+            var res = Convert.ToBase64String(guid.ToByteArray());
+            var res2 = Regex.Replace(res, @"[^a-zA-Z0-9]", "");
+             return res2+".dump";
+        }
+
+
+        public void AddString(string text)
+        {
+            txt.Append(text);
+        }
+
+    }
+
+#if !NETCOREAPP1_0
+    public static class XmlNodeExtension
+    {
+        public static string AsString(this System.Xml.XmlNode node)
+        {
+            using (var swriter = new System.IO.StringWriter())
+            {
+                using (var twriter = new System.Xml.XmlTextWriter(swriter))
+                {
+                    twriter.Formatting = System.Xml.Formatting.Indented;
+                    twriter.Indentation = 3;
+                    twriter.QuoteChar = '\'';
+                    node.WriteContentTo(twriter);
+                }
+                return swriter.ToString();
+            }
+        }
+    }
+#endif
+}

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -73,7 +73,7 @@ namespace NUnit.VisualStudio.TestAdapter
         {
             var node = XmlHelper.CreateXmlNode(report);
 #if !NETCOREAPP1_0
-            dumpXml?.AddString(node.AsString());
+            dumpXml?.AddTestEvent(node.AsString());
 #endif
             try
             {

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using NUnit.Engine;
+using NUnit.VisualStudio.TestAdapter.Dump;
 using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 namespace NUnit.VisualStudio.TestAdapter
@@ -59,8 +60,9 @@ namespace NUnit.VisualStudio.TestAdapter
         }
 #endif
 
-        public NUnitEventListener(ITestExecutionRecorder recorder, TestConverter testConverter)
+        public NUnitEventListener(ITestExecutionRecorder recorder, TestConverter testConverter, IDumpXml dumpXml)
         {
+            this.dumpXml = dumpXml;
             _recorder = recorder;
             _testConverter = testConverter;
         }
@@ -70,7 +72,9 @@ namespace NUnit.VisualStudio.TestAdapter
         public void OnTestEvent(string report)
         {
             var node = XmlHelper.CreateXmlNode(report);
-
+#if !NETCOREAPP1_0
+            dumpXml?.AddString(node.AsString());
+#endif
             try
             {
                 switch (node.Name)
@@ -182,6 +186,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         private static readonly string NL = Environment.NewLine;
         private static readonly int NL_LENGTH = NL.Length;
+        private IDumpXml dumpXml;
 
         public void TestOutput(XmlNode outputNode)
         {

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -120,6 +120,7 @@ namespace NUnit.VisualStudio.TestAdapter
             TestEngine = new TestEngineClass();
             TestLog = new TestLogger(messageLogger);
             Settings = new AdapterSettings(TestLog);
+            TestLog.InitSettings(Settings);
 
             try
             {

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -38,18 +38,24 @@ namespace NUnit.VisualStudio.TestAdapter
     /// </summary>
     public class TestLogger : IMessageLogger
     {
+        private IAdapterSettings adapterSettings;
         private const string EXCEPTION_FORMAT = "Exception {0}, {1}";
 
         private IMessageLogger MessageLogger { get; set; }
 
         public int Verbosity { get; set; }
 
-        public TestLogger(IMessageLogger messageLogger) : this(messageLogger, 0) { }
-
-        public TestLogger(IMessageLogger messageLogger, int verbosity)
+        public TestLogger(IMessageLogger messageLogger)
         {
+
             MessageLogger = messageLogger;
-            Verbosity = verbosity;
+        }
+
+        public TestLogger InitSettings(IAdapterSettings settings)
+        {
+            adapterSettings = settings;
+            Verbosity = adapterSettings.Verbosity;
+            return this;
         }
 
         #region Error Messages
@@ -73,7 +79,7 @@ namespace NUnit.VisualStudio.TestAdapter
             SendMessage(TestMessageLevel.Warning, message);
         }
 
-        public void Warning(string message,Exception ex)
+        public void Warning(string message, Exception ex)
         {
             SendMessage(TestMessageLevel.Warning, message, ex);
         }
@@ -93,9 +99,9 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public void Debug(string message)
         {
-#if DEBUG
-            SendMessage(TestMessageLevel.Informational, message);
-#endif
+            if (adapterSettings?.Verbosity >= 5)
+                SendMessage(TestMessageLevel.Informational, message);
+
         }
 
         #endregion
@@ -116,10 +122,10 @@ namespace NUnit.VisualStudio.TestAdapter
                     var type = ex.GetType();
                     SendMessage(testMessageLevel, string.Format(EXCEPTION_FORMAT, type, message));
                     SendMessage(testMessageLevel, ex.Message);
-                    SendMessage(testMessageLevel,ex.StackTrace);
+                    SendMessage(testMessageLevel, ex.StackTrace);
                     if (ex.InnerException != null)
                     {
-                        SendMessage(testMessageLevel,$"Innerexception: {ex.InnerException.ToString()}");
+                        SendMessage(testMessageLevel, $"Innerexception: {ex.InnerException.ToString()}");
                     }
                     break;
 

--- a/src/NUnitTestAdapterTests/DumpXmlTests.cs
+++ b/src/NUnitTestAdapterTests/DumpXmlTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Text.RegularExpressions;
+using NSubstitute;
+using NUnit.Framework;
+using NUnit.VisualStudio.TestAdapter.Dump;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests
+{
+    [Category(nameof(DumpXml))]
+    public class DumpXmlTests
+    {
+        [Test]
+        public void ThatWritingClearsBuffer()
+        {
+            var file = Substitute.For<IFile>();
+            var sut = new DumpXml("whatever",file);
+            var string1 = "something";
+            sut.AddString(string1);
+            sut.Dump4Discovery();
+            file.Received().WriteAllText(Arg.Any<string>(),Arg.Is<string>(o=>o==string1));
+            var string2 = "new string";
+            sut.AddString(string2);
+            sut.Dump4Discovery();
+            file.Received().WriteAllText(Arg.Any<string>(), Arg.Is<string>(o => o == string2));
+        }
+
+        [Test]
+        public void ThatRandomNameContainsValidCharacters()
+        {
+            var sut = new DumpXml("whatever");
+            var res = sut.RandomName();
+            Assert.That(res.EndsWith(".dump"));
+            var parts = res.Split('.');
+            Assert.That(parts.Length,Is.EqualTo(2),$"Too many dots in {res}");
+            var part1 = parts[0];
+            var rg = new Regex(@"^[a-zA-Z0-9\s]*$");
+            Assert.That(rg.IsMatch(part1));
+        }
+
+        [TestCase(@"C:\MyFolder\Whatever.dll", @"C:\MyFolder\Dump\D_Whatever.dll.dump")]
+        [TestCase(@"C:\MyFolder\Whatever.dll", @"C:\MyFolder\Dump")]
+        [TestCase(@"C:\MyFolder\Whatever.dll",@"C:\MyFolder")]
+        public void ThatPathIsCorrectlyParsedInDiscoveryPhase(string path,string expected)
+        {
+            var file = Substitute.For<IFile>();
+            var sut = new DumpXml(path,file);
+            sut.AddString("whatever");
+            sut.Dump4Discovery();
+            file.Received().WriteAllText(Arg.Is<string>(o=>o.StartsWith(expected)),Arg.Any<string>());
+
+        }
+    }
+}

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="nunit3testadapter" Version="3.8.0" />
     <PackageReference Include="NUnitLite" Version="3.8.1" />

--- a/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
@@ -48,14 +48,14 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void SetUp()
         {
             testLog = new FakeFrameworkHandle();
-            testConverter = new TestConverter(new TestLogger(new MessageLoggerStub(), 0), FakeTestData.AssemblyPath, collectSourceInformation: true);
+            testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath, collectSourceInformation: true);
             fakeTestNode = FakeTestData.GetTestNode();
 
             // Ensure that the converted testcase is cached
             testConverter.ConvertTestCase(fakeTestNode);
             Assert.NotNull(testConverter.GetCachedTestCase("123"));
             
-            listener = new NUnitEventListener(testLog, testConverter);
+            listener = new NUnitEventListener(testLog, testConverter,null);
         }
 
         #region TestStarted Tests
@@ -147,7 +147,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void Listener_LeaseLifetimeWillNotExpire()
         {
             testLog = new FakeFrameworkHandle();
-            testConverter = new TestConverter(new TestLogger(new MessageLoggerStub(), 0), FakeTestData.AssemblyPath, collectSourceInformation: true);
+            testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath, collectSourceInformation: true);
             MarshalByRefObject localInstance = (MarshalByRefObject)Activator.CreateInstance(typeof(NUnitEventListener), testLog, testConverter);
 
             RemotingServices.Marshal(localInstance);

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -45,7 +45,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void SetUp()
         {
             fakeTestNode = FakeTestData.GetTestNode();
-            testConverter = new TestConverter(new TestLogger(new MessageLoggerStub(), 0), FakeTestData.AssemblyPath, collectSourceInformation: true);
+            testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath, collectSourceInformation: true);
         }
 
         [Test]


### PR DESCRIPTION
This PR will add support for generating xml file outputs, aimed at debugging and investigations, but can surely be used otherwise too.  
It works now for .net fw, but not currently for .net core, need a touch on the xml text writing, which is what is stopping it there. 

It is controlled by two new settings in the runsettings file,
   DumpXmlTestDiscovery
   DumpXmlTestResults

It will output the xml files into the same folder as the assembly under test, into a subfolder named "Dump", and with a filename equal to the assembly name, but with the .dump extension
Further, the discovery file is prefixed with "D_" and the execution file with "E_" 

The execution file will contain anything found during start of the run, and also anything received through the run events. 

