### PR TITLE
add `System.Runtime.InteropServices.RuntimeInformation` dependency for netcoreapp1.0

### DIFF
--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -28,6 +28,7 @@ The package works with Visual Studio 2012 and newer.</description>
             <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" />
             <dependency id="System.Diagnostics.Process" version="4.3.0" />
             <dependency id="System.Reflection" version="4.3.0" />
+            <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
             <dependency id="System.Threading.Thread" version="4.3.0" />
             <dependency id="System.Xml.XmlDocument" version="4.3.0" />
             <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" />


### PR DESCRIPTION
Possible fix for #365.

Running `dotnet test` for C# and VB.NET projects targeting netcoreapp-1.0 always failed with the error:

```
An exception occurred while invoking executor 'executor://nunit3testexecutor/': Could not load file or assembly 'System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
```

Here is one of failed build for example: https://travis-ci.org/halex2005/dotnet-new-nunit/jobs/304079301
