### PR TITLE
Changed categories from traits to category properties, aligning them …

### DIFF
--- a/src/NUnitTestAdapter/CategoryList.cs
+++ b/src/NUnitTestAdapter/CategoryList.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+namespace NUnit.VisualStudio.TestAdapter
+{
+    public class CategoryList
+    {
+        public const string NUnitCategoryName = "NUnit.TestCategory";
+        private const string NunitTestCategoryLabel = "Category";
+        private const string VsTestCategoryLabel = "TestCategory";
+        internal static readonly TestProperty NUnitTestCategoryProperty = TestProperty.Register(NUnitCategoryName, VsTestCategoryLabel, typeof(string[]), TestPropertyAttributes.Hidden | TestPropertyAttributes.Trait, typeof(TestCase));
+
+        private readonly List<string> categorylist = new List<string>();
+        private readonly TestCase testCase;
+
+        public CategoryList(TestCase testCase)
+        {
+            this.testCase = testCase;
+        }
+
+        public void AddRange(IEnumerable<string> categories)
+        {
+            categorylist.AddRange(categories);
+        }
+
+        public int LastNodeListCount { get; private set; }
+        public IEnumerable<string> ProcessTestCaseProperties(XmlNode testNode, bool addToCache, string key = null, IDictionary<string, List<Trait>> traitsCache = null)
+        {
+            var nodelist = testNode.SelectNodes("properties/property");
+            LastNodeListCount = nodelist.Count;
+            foreach (XmlNode propertyNode in nodelist)
+            {
+                string propertyName = propertyNode.GetAttribute("name");
+                string propertyValue = propertyNode.GetAttribute("value");
+                if (addToCache)
+                    AddTraitsToCache(traitsCache, key, propertyName, propertyValue);
+                if (!IsInternalProperty(propertyName, propertyValue))
+                {
+                    if (propertyName != NunitTestCategoryLabel)
+                        testCase.Traits.Add(new Trait(propertyName, propertyValue));
+                    else
+                    {
+                        categorylist.Add(propertyValue);
+                    }
+                }
+            }
+            return categorylist;
+        }
+
+        private static bool IsInternalProperty(string propertyName, string propertyValue)
+        {
+            // Property names starting with '_' are for internal use only
+            return String.IsNullOrEmpty(propertyName) || propertyName[0] == '_' || String.IsNullOrEmpty(propertyValue);
+        }
+
+        private static void AddTraitsToCache(IDictionary<string, List<Trait>> traitsCache, string key, string propertyName, string propertyValue)
+        {
+            if (traitsCache.ContainsKey(key))
+            {
+                if (!IsInternalProperty(propertyName, propertyValue))
+                    traitsCache[key].Add(new Trait(propertyName, propertyValue));
+                return;
+            }
+
+            var traits = new List<Trait>();
+
+            // Will add empty list of traits, if the property is internal type. So that we will not make SelectNodes call again.
+            if (!IsInternalProperty(propertyName, propertyValue))
+            {
+                traits.Add(new Trait(propertyName, propertyValue));
+            }
+            traitsCache[key] = traits;
+        }
+
+        public void UpdateCategoriesToVs()
+        {
+            if (categorylist.Any())
+            {
+                testCase.SetPropertyValue(NUnitTestCategoryProperty, categorylist.Distinct().ToArray());
+            }
+        }
+
+
+
+    }
+}

--- a/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
+++ b/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// ****************************************************************
-// Copyright (c) 2011 Charlie Poole, Terje Sandstrom.
+// Copyright (c) 2011-2018 Charlie Poole, Terje Sandstrom.
 // ****************************************************************
 
 using System;
@@ -20,5 +20,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 [assembly: Guid("c0aad5e4-b486-49bc-b3e8-31e01be6fefe")]
-[assembly: AssemblyVersion("3.9.0.0")]
-[assembly: AssemblyFileVersion("3.9.0.0")]
+[assembly: AssemblyVersion("3.10.0.21")]
+[assembly: AssemblyFileVersion("3.10.0.21")]

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -160,7 +160,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 }
             }
 
-            testCase.AddTraitsFromTestNode(testNode, TraitsCache);
+            testCase.AddTraitsFromTestNode(testNode, TraitsCache,_logger);
 
             return testCase;
         }

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2011-2015 Charlie Poole, Terje Sandstrom
+// Copyright (c) 2011-2018 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -23,15 +23,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Xml;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
 {
@@ -96,15 +92,15 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             CheckNoTestCaseNodesExist(traitsCache);
 
             // Checking assembly level attribute.
-            CheckNodeProperties(traitsCache, "0-1009", new KeyValuePair<string, string>[] { new KeyValuePair<string, string>("Category", "AsmCat") });
+            CheckNodeProperties(traitsCache, "0-1009", new[] { new KeyValuePair<string, string>("Category", "AsmCat") });
 
             // Checking Class level attributes base class & dervied class
-            CheckNodeProperties(traitsCache, "0-1000", new KeyValuePair<string,string>[] { new KeyValuePair<string, string>("Category", "BaseClass") });
-            CheckNodeProperties(traitsCache, "0-1002", new KeyValuePair<string, string>[] { new KeyValuePair<string, string>("Category", "DerivedClass"), new KeyValuePair<string, string>("Category", "BaseClass") });
+            CheckNodeProperties(traitsCache, "0-1000", new[] { new KeyValuePair<string, string>("Category", "BaseClass") });
+            CheckNodeProperties(traitsCache, "0-1002", new[] { new KeyValuePair<string, string>("Category", "DerivedClass"), new KeyValuePair<string, string>("Category", "BaseClass") });
 
             // Checking Nested class attributes.
-            CheckNodeProperties(traitsCache, "0-1005", new KeyValuePair<string, string>[] { new KeyValuePair<string, string>("Category", "NS1") });
-            CheckNodeProperties(traitsCache, "0-1007", new KeyValuePair<string, string>[] { new KeyValuePair<string, string>("Category", "NS2") });
+            CheckNodeProperties(traitsCache, "0-1005", new[] { new KeyValuePair<string, string>("Category", "NS1") });
+            CheckNodeProperties(traitsCache, "0-1007", new[] { new KeyValuePair<string, string>("Category", "NS2") });
 
         }
 
@@ -157,8 +153,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 Assert.That(testCase.LineNumber, Is.EqualTo(FakeTestData.LineNumber));
             }
 
-                var traitList = testCase.GetTraits().Select(trait => trait.Name + ":" + trait.Value).ToList();
-                Assert.That(traitList, Is.EquivalentTo(new[] { "Category:super", "Category:cat1", "Priority:medium" }));
+            var traitList = testCase.GetTraits().Select(trait => trait.Name + ":" + trait.Value).ToList();
+            Assert.That(traitList, Is.EquivalentTo(new[] { "Priority:medium" }));
+            Assert.That(testCase.GetCategories(),Is.EquivalentTo(new [] { "super", "cat1", }));
         }
 
         private void CheckNodesWithNoProperties(IDictionary<string, List<Trait>> traits)

--- a/src/NUnitTestAdapterTests/VsExperimentalTests.cs
+++ b/src/NUnitTestAdapterTests/VsExperimentalTests.cs
@@ -1,0 +1,60 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018-2018 Charlie Poole, Terje Sandstrom
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************using System;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NUnit.Framework;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests
+{
+    /// <summary>
+    /// Experimental tests used to deduce functionality of VSTest
+    /// </summary>
+    public class VsExperimentalTests
+    {
+        [Test]
+        public void ThatCategoriesAreDistinct()
+        {
+            var testCase = new TestCase(
+                "whatever",
+                new Uri(NUnitTestAdapter.ExecutorUri),
+                "someassemblyname")
+            {
+                DisplayName = nameof(ThatCategoriesAreDistinct),
+                CodeFilePath = null,
+                LineNumber = 0
+            };
+            var cl = new CategoryList(testCase);
+            cl.AddRange(new List<string> {"one","one","two","two"});
+            cl.UpdateCategoriesToVs();
+
+            var returnedCategoryList = testCase.GetCategories();
+            Assert.That(returnedCategoryList.Count(),Is.EqualTo(2),$"Found {testCase.GetCategories().Count()} category entries");
+
+        }
+    }
+}


### PR DESCRIPTION
…with what MSTest does, and VSTest supports.  #310 

Handing of categories is moved from the traits class, which where extension methods, into its own class CategoryList.   
NUnit delivers all traits as property/value pairs, and those who are marked as Category are now processed as properties.  The rest are unchanged. 
The tests have been updated to check for both categories and traits. 