### PR TITLE
Added circuit breaker to prevent performance problem

### DIFF
--- a/src/NUnitTestAdapter/Metadata/IMetadataProvider.cs
+++ b/src/NUnitTestAdapter/Metadata/IMetadataProvider.cs
@@ -25,7 +25,7 @@ using System;
 
 namespace NUnit.VisualStudio.TestAdapter.Metadata
 {
-    internal interface IMetadataProvider : IDisposable
+    public interface IMetadataProvider : IDisposable
     {
         TypeInfo? GetDeclaringType(string assemblyPath, string reflectedTypeName, string methodName);
         TypeInfo? GetStateMachineType(string assemblyPath, string reflectedTypeName, string methodName);

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -50,7 +50,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
             if (_collectSourceInformation)
             {
-                _navigationDataProvider = new NavigationDataProvider(sourceAssembly);
+                _navigationDataProvider = new NavigationDataProvider(sourceAssembly, logger);
             }
         }
 

--- a/src/NUnitTestAdapterTests/NavigationDataProviderTests.cs
+++ b/src/NUnitTestAdapterTests/NavigationDataProviderTests.cs
@@ -1,0 +1,56 @@
+﻿using NSubstitute;
+using NUnit.Framework;
+using NUnit.VisualStudio.TestAdapter.Metadata;
+using System;
+using System.Reflection;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests
+{
+    public static class NavigationDataProviderTests
+    {
+        [Test]
+        public static void ExceptionShouldDisableGetStateMachineTypeAndLogErrorForAssembly()
+        {
+            var fixture = new Fixture();
+            fixture.MetadataProvider.GetStateMachineType(null, null, null).ReturnsForAnyArgs(_ => throw new Exception());
+
+            fixture.CauseLookupFailure();
+
+            fixture.MetadataProvider.ReceivedWithAnyArgs(requiredNumberOfCalls: 1).GetStateMachineType(null, null, null);
+            fixture.AssertLoggerReceivedErrorForAssemblyPath();
+        }
+
+        [Test]
+        public static void ExceptionShouldDisableGetDeclaringTypeAndLogErrorForAssembly()
+        {
+            var fixture = new Fixture();
+            fixture.MetadataProvider.GetDeclaringType(null, null, null).ReturnsForAnyArgs(_ => throw new Exception());
+
+            fixture.CauseLookupFailure();
+
+            fixture.MetadataProvider.ReceivedWithAnyArgs(requiredNumberOfCalls: 1).GetDeclaringType(null, null, null);
+            fixture.AssertLoggerReceivedErrorForAssemblyPath();
+        }
+
+        private sealed class Fixture
+        {
+            public ITestLogger Logger { get; } = Substitute.For<ITestLogger>();
+            public IMetadataProvider MetadataProvider { get; } = Substitute.For<IMetadataProvider>();
+            private readonly string _existingAssemblyPath = typeof(NavigationDataProviderTests).GetTypeInfo().Assembly.Location;
+
+            public void CauseLookupFailure()
+            {
+                using (var navigationProvider = new NavigationDataProvider(_existingAssemblyPath, Logger, MetadataProvider))
+                {
+                    navigationProvider.GetNavigationData("NonExistentFixture", "SomeTest");
+                    navigationProvider.GetNavigationData("NonExistentFixture", "SomeTest");
+                }
+            }
+
+            public void AssertLoggerReceivedErrorForAssemblyPath()
+            {
+                Logger.Received().Warning(Arg.Is<string>(message => message.Contains(_existingAssemblyPath)), Arg.Any<Exception>());
+            }
+        }
+    }
+}

--- a/src/NUnitTestAdapterTests/NavigationDataTests.cs
+++ b/src/NUnitTestAdapterTests/NavigationDataTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Reflection;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
@@ -15,7 +16,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void SetUp()
         {
             _provider = new NavigationDataProvider(
-                typeof(NavigationDataTests).GetTypeInfo().Assembly.Location);
+                typeof(NavigationDataTests).GetTypeInfo().Assembly.Location,
+                Substitute.For<ITestLogger>());
         }
 
         [TearDown]


### PR DESCRIPTION
Fixes #460.

Tested against the problem project. This PR resolves the performance issue. In a separate PR, I'll figure out why the reflection appdomain is failing to load nunit.framework.dll for the problem project.