### PR TITLE
Upgrade Cake from 0.22 so that error messages are readable

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ Param(
     [string[]]$ScriptArgs
 )
 
-$CakeVersion = "0.22.1"
+$CakeVersion = "0.26.0"
 $DotNetChannel = "preview";
 $DotNetVersion = "1.1.4";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";


### PR DESCRIPTION
Cake 0.22 has a bug where all exceptions got wrapped in AggregateException , effectively preventing you from seeing the error message. It kept getting in the way.