### PR TITLE
Block explicit tests for 3.10

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -178,9 +178,7 @@ foreach (var (framework, vstestFramework, adapterDir) in new[] {
             VSTest(GetTestAssemblyPath(framework), settings);
         });
 
-    // Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/47
-    // (presence of a filter causes explicit tests to start running)
-    const string NoNavigationTests = "TestCategory!=Navigation&TestCategory!=LongRunning";
+    const string NoNavigationTests = "TestCategory != Navigation";
 
     Task($"DotnetTest-{framework}")
         .IsDependentOn("Build")

--- a/src/NUnitTestAdapter/CategoryList.cs
+++ b/src/NUnitTestAdapter/CategoryList.cs
@@ -13,6 +13,8 @@ namespace NUnit.VisualStudio.TestAdapter
         private const string VsTestCategoryLabel = "TestCategory";
         internal static readonly TestProperty NUnitTestCategoryProperty = TestProperty.Register(NUnitCategoryName, VsTestCategoryLabel, typeof(string[]), TestPropertyAttributes.Hidden | TestPropertyAttributes.Trait, typeof(TestCase));
 
+        internal static readonly TestProperty NUnitExplicitProperty = TestProperty.Register("NUnit.Explicit", "Explicit", typeof(bool), TestPropertyAttributes.Hidden, typeof(TestCase));
+
         private const string ExplicitTraitName = "Explicit";
         // The empty string causes the UI we want.
         // If it's null, the explicit trait doesn't show up in Test Explorer.
@@ -56,12 +58,20 @@ namespace NUnit.VisualStudio.TestAdapter
 
             if (testNode.Attributes?["runstate"]?.Value == "Explicit")
             {
+                // Add UI grouping “Explicit”
                 if (!testCase.Traits.Any(trait => trait.Name == ExplicitTraitName))
-                {
                     testCase.Traits.Add(new Trait(ExplicitTraitName, ExplicitTraitValue));
 
-                    if (addToCache)
-                        AddTraitsToCache(traitsCache, key, ExplicitTraitName, ExplicitTraitValue);
+                // Track whether the test is actually explicit since multiple things result in the same UI grouping
+                testCase.SetPropertyValue(NUnitExplicitProperty, true);
+
+                if (addToCache)
+                {
+                    // Add UI grouping “Explicit”
+                    AddTraitsToCache(traitsCache, key, ExplicitTraitName, ExplicitTraitValue);
+
+                    // Track whether the test is actually explicit since multiple things result in the same UI grouping
+                    AddTraitsToCache(traitsCache, key, "No great way to cache explicit property in IDictionary<string, List<Trait>>", "MAGIC");
                 }
             }
 

--- a/src/NUnitTestAdapter/CategoryList.cs
+++ b/src/NUnitTestAdapter/CategoryList.cs
@@ -35,7 +35,7 @@ namespace NUnit.VisualStudio.TestAdapter
         }
 
         public int LastNodeListCount { get; private set; }
-        public IEnumerable<string> ProcessTestCaseProperties(XmlNode testNode, bool addToCache, string key = null, IDictionary<string, List<Trait>> traitsCache = null)
+        public IEnumerable<string> ProcessTestCaseProperties(XmlNode testNode, bool addToCache, string key = null, IDictionary<string, TraitsFeature.CachedTestCaseInfo> traitsCache = null)
         {
             var nodelist = testNode.SelectNodes("properties/property");
             LastNodeListCount = nodelist.Count;
@@ -71,7 +71,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     AddTraitsToCache(traitsCache, key, ExplicitTraitName, ExplicitTraitValue);
 
                     // Track whether the test is actually explicit since multiple things result in the same UI grouping
-                    AddTraitsToCache(traitsCache, key, "No great way to cache explicit property in IDictionary<string, List<Trait>>", "MAGIC");
+                    GetCachedInfo(traitsCache, key).Explicit = true;
                 }
             }
 
@@ -91,23 +91,19 @@ namespace NUnit.VisualStudio.TestAdapter
             return String.IsNullOrEmpty(propertyName) || propertyName[0] == '_' || String.IsNullOrEmpty(propertyValue);
         }
 
-        private static void AddTraitsToCache(IDictionary<string, List<Trait>> traitsCache, string key, string propertyName, string propertyValue)
+        private static void AddTraitsToCache(IDictionary<string, TraitsFeature.CachedTestCaseInfo> traitsCache, string key, string propertyName, string propertyValue)
         {
-            if (traitsCache.ContainsKey(key))
-            {
-                if (!IsInternalProperty(propertyName, propertyValue))
-                    traitsCache[key].Add(new Trait(propertyName, propertyValue));
-                return;
-            }
+            if (IsInternalProperty(propertyName, propertyValue)) return;
 
-            var traits = new List<Trait>();
+            var info = GetCachedInfo(traitsCache, key);
+            info.Traits.Add(new Trait(propertyName, propertyValue));
+        }
 
-            // Will add empty list of traits, if the property is internal type. So that we will not make SelectNodes call again.
-            if (!IsInternalProperty(propertyName, propertyValue))
-            {
-                traits.Add(new Trait(propertyName, propertyValue));
-            }
-            traitsCache[key] = traits;
+        private static TraitsFeature.CachedTestCaseInfo GetCachedInfo(IDictionary<string, TraitsFeature.CachedTestCaseInfo> traitsCache, string key)
+        {
+            if (!traitsCache.TryGetValue(key, out var info))
+                traitsCache.Add(key, info = new TraitsFeature.CachedTestCaseInfo());
+            return info;
         }
 
         public void UpdateCategoriesToVs()

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -46,7 +46,7 @@ namespace NUnit.VisualStudio.TestAdapter
             _sourceAssembly = sourceAssembly;
             _vsTestCaseMap = new Dictionary<string, TestCase>();
             _collectSourceInformation = collectSourceInformation;
-            TraitsCache = new Dictionary<string, List<Trait>>();
+            TraitsCache = new Dictionary<string, TraitsFeature.CachedTestCaseInfo>();
 
             if (_collectSourceInformation)
             {
@@ -59,7 +59,7 @@ namespace NUnit.VisualStudio.TestAdapter
             _navigationDataProvider?.Dispose();
         }
 
-        public IDictionary<string, List<Trait>> TraitsCache { get; }
+        public IDictionary<string, TraitsFeature.CachedTestCaseInfo> TraitsCache { get; }
 
         #region Public Methods
         /// <summary>

--- a/src/NUnitTestAdapter/TfsTestFilter.cs
+++ b/src/NUnitTestAdapter/TfsTestFilter.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -44,7 +44,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
     public class TfsTestFilter : ITfsTestFilter
     {
-        /// <summary>   
+        /// <summary>
         /// Supported properties for filtering
 
         ///</summary>
@@ -104,14 +104,18 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public IEnumerable<TestCase> CheckFilter(IEnumerable<TestCase> tests)
         {
-
-            return TfsTestCaseFilterExpression == null ? tests : tests.Where(underTest => !TfsTestCaseFilterExpression.MatchTestCase(underTest, p => PropertyValueProvider(underTest, p)) == false).ToList();
+            return TfsTestCaseFilterExpression == null ? tests : tests.Where(CheckFilter).ToList();
         }
 
-        /// <summary>    
-        /// Provides value of TestProperty corresponding to property name 'propertyName' as used in filter.    
-        /// /// Return value should be a string for single valued property or array of strings for multi valued property (e.g. TestCategory)   
-        /// /// </summary>     
+        private bool CheckFilter(TestCase testCase)
+        {
+            return TfsTestCaseFilterExpression.MatchTestCase(testCase, p => PropertyValueProvider(testCase, p));
+        }
+
+        /// <summary>
+        /// Provides value of TestProperty corresponding to property name 'propertyName' as used in filter.
+        /// /// Return value should be a string for single valued property or array of strings for multi valued property (e.g. TestCategory)
+        /// /// </summary>
         public static object PropertyValueProvider(TestCase currentTest, string propertyName)
         {
 
@@ -119,8 +123,8 @@ namespace NUnit.VisualStudio.TestAdapter
             if (testProperty != null)
             {
 
-                // Test case might not have defined this property. In that case GetPropertyValue()             
-                // would return default value. For filtering, if property is not defined return null.           
+                // Test case might not have defined this property. In that case GetPropertyValue()
+                // would return default value. For filtering, if property is not defined return null.
                 if (currentTest.Properties.Contains(testProperty))
                 {
                     return currentTest.GetPropertyValue(testProperty);
@@ -134,7 +138,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 if (val.Length == 0) return null;
                 if (val.Length == 1) // Contains a single string
                     return val[0];  // return that string
-                return val;  // otherwise return the whole array 
+                return val;  // otherwise return the whole array
             }
             return null;
         }
@@ -160,9 +164,9 @@ namespace NUnit.VisualStudio.TestAdapter
             };
         }
 
-        /// <summary>   
-        /// Provides TestProperty for property name 'propertyName' as used in filter.    
-        /// </summary>    
+        /// <summary>
+        /// Provides TestProperty for property name 'propertyName' as used in filter.
+        /// </summary>
         public static TestProperty LocalPropertyProvider(string propertyName)
         {
             TestProperty testProperty;

--- a/src/NUnitTestAdapter/TfsTestFilter.cs
+++ b/src/NUnitTestAdapter/TfsTestFilter.cs
@@ -104,12 +104,14 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public IEnumerable<TestCase> CheckFilter(IEnumerable<TestCase> tests)
         {
-            return TfsTestCaseFilterExpression == null ? tests : tests.Where(CheckFilter).ToList();
+            return tests.Where(CheckFilter).ToList();
         }
 
         private bool CheckFilter(TestCase testCase)
         {
-            return TfsTestCaseFilterExpression.MatchTestCase(testCase, p => PropertyValueProvider(testCase, p));
+            var isExplicit = testCase.GetPropertyValue(CategoryList.NUnitExplicitProperty, false);
+
+            return !isExplicit && TfsTestCaseFilterExpression?.MatchTestCase(testCase, p => PropertyValueProvider(testCase, p)) != false;
         }
 
         /// <summary>

--- a/src/NUnitTestAdapter/TfsTestFilter.cs
+++ b/src/NUnitTestAdapter/TfsTestFilter.cs
@@ -114,8 +114,8 @@ namespace NUnit.VisualStudio.TestAdapter
 
         /// <summary>
         /// Provides value of TestProperty corresponding to property name 'propertyName' as used in filter.
-        /// /// Return value should be a string for single valued property or array of strings for multi valued property (e.g. TestCategory)
-        /// /// </summary>
+        /// Return value should be a string for single valued property or array of strings for multi valued property (e.g. TestCategory)
+        /// </summary>
         public static object PropertyValueProvider(TestCase currentTest, string propertyName)
         {
 

--- a/src/NUnitTestAdapter/TraitsFeature.cs
+++ b/src/NUnitTestAdapter/TraitsFeature.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -35,8 +35,8 @@ namespace NUnit.VisualStudio.TestAdapter
             testCase?.Traits.Add(new Trait(name, value));
         }
         private const string NunitTestCategoryLabel = "Category";
-       
-       
+
+
         public static void AddTraitsFromTestNode(this TestCase testCase, XmlNode testNode,
             IDictionary<string, List<Trait>> traitsCache, ITestLogger logger)
         {
@@ -49,7 +49,11 @@ namespace NUnit.VisualStudio.TestAdapter
                 if (traitsCache.ContainsKey(key))
                 {
                     categorylist.AddRange(traitsCache[key].Where(o => o.Name == NunitTestCategoryLabel).Select(prop => prop.Value).ToList());
-                    var traitslist = traitsCache[key].Where(o => o.Name != NunitTestCategoryLabel).ToList();
+
+                    if (traitsCache[key].Any(o => o.Name == "No great way to cache explicit property in IDictionary<string, List<Trait>>"))
+                        testCase.SetPropertyValue(CategoryList.NUnitExplicitProperty, true);
+
+                    var traitslist = traitsCache[key].Where(o => o.Name != NunitTestCategoryLabel && o.Name != "No great way to cache explicit property in IDictionary<string, List<Trait>>").ToList();
                     if (traitslist.Count > 0)
                         testCase.Traits.AddRange(traitslist);
                 }
@@ -71,7 +75,7 @@ namespace NUnit.VisualStudio.TestAdapter
             categorylist.UpdateCategoriesToVs();
         }
 
-       
+
         public static IEnumerable<NTrait> GetTraits(this TestCase testCase)
         {
             var traits = new List<NTrait>();

--- a/src/NUnitTestAdapter/TraitsFeature.cs
+++ b/src/NUnitTestAdapter/TraitsFeature.cs
@@ -37,10 +37,26 @@ namespace NUnit.VisualStudio.TestAdapter
         private const string NunitTestCategoryLabel = "Category";
 
 
+        /// <summary>
+        /// Stores the information needed to initialize a <see cref="TestCase"/>
+        /// which can be inherited from an ancestor node during the conversion of test cases.
+        /// </summary>
         public sealed class CachedTestCaseInfo
         {
+            /// <summary>
+            /// Used to populate a test case’s <see cref="TestObject.Traits"/> collection.
+            /// Currently, the only effect this has is to add a Test Explorer grouping header
+            /// for each trait with the name “Name [Value]”, or for an empty value, “Name”.
+            /// </summary>
             public List<Trait> Traits { get; } = new List<Trait>();
+
+            /// <summary>
+            /// Used by <see cref="TfsTestFilter"/>; does not affect the Test Explorer UI.
+            /// </summary>
             public bool Explicit { get; set; }
+
+            // Eventually, we might split out the Categories collection and make this
+            // an immutable struct. (https://github.com/nunit/nunit3-vs-adapter/pull/457)
         }
 
         public static void AddTraitsFromTestNode(this TestCase testCase, XmlNode testNode,

--- a/src/NUnitTestAdapterTests/Filtering/FilteringTestUtils.cs
+++ b/src/NUnitTestAdapterTests/Filtering/FilteringTestUtils.cs
@@ -1,0 +1,78 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Terje Sandstrom
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using NSubstitute;
+using NUnit.Framework;
+using NUnit.VisualStudio.TestAdapter.Tests.Fakes;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
+{
+    public static class FilteringTestUtils
+    {
+        public static ITestCaseFilterExpression CreateVSTestFilterExpression(string filter)
+        {
+            var filterExpressionWrapperType = Type.GetType("Microsoft.VisualStudio.TestPlatform.Common.Filtering.FilterExpressionWrapper, Microsoft.VisualStudio.TestPlatform.Common", throwOnError: true);
+
+            var filterExpressionWrapper =
+                filterExpressionWrapperType.GetTypeInfo()
+                .GetConstructor(new[] { typeof(string) })
+                .Invoke(new object[] { filter });
+
+            return (ITestCaseFilterExpression)
+                Type.GetType("Microsoft.VisualStudio.TestPlatform.Common.Filtering.TestCaseFilterExpression, Microsoft.VisualStudio.TestPlatform.Common", throwOnError: true).GetTypeInfo()
+                .GetConstructor(new[] { filterExpressionWrapperType })
+                .Invoke(new object[] { filterExpressionWrapper });
+        }
+
+        public static TfsTestFilter CreateTestFilter(ITestCaseFilterExpression filterExpression)
+        {
+            var context = Substitute.For<IRunContext>();
+            context.GetTestCaseFilter(null, null).ReturnsForAnyArgs(filterExpression);
+            return new TfsTestFilter(context);
+        }
+
+        public static void AssertExpectedResult(ITestCaseFilterExpression filterExpression, IReadOnlyCollection<TestCase> testCases, IReadOnlyCollection<string> expectedMatchingTestNames)
+        {
+            var matchingTestCases = CreateTestFilter(filterExpression).CheckFilter(testCases);
+
+            Assert.That(matchingTestCases.Select(t => t.FullyQualifiedName), Is.EquivalentTo(expectedMatchingTestNames));
+        }
+
+        public static IReadOnlyCollection<TestCase> ConvertTestCases(string xml)
+        {
+            using (var testConverter = new TestConverter(
+                new TestLogger(new MessageLoggerStub()),
+                FakeTestData.AssemblyPath,
+                collectSourceInformation: false))
+            {
+                return testConverter.ConvertTestCases(xml);
+            }
+        }
+    }
+}

--- a/src/NUnitTestAdapterTests/Filtering/TestDoubleFilterExpression.cs
+++ b/src/NUnitTestAdapterTests/Filtering/TestDoubleFilterExpression.cs
@@ -1,0 +1,58 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Terje Sandstrom
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections;
+using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
+{
+    public sealed class TestDoubleFilterExpression : ITestCaseFilterExpression
+    {
+        private readonly Func<Func<string, object>, bool> predicate;
+
+        public TestDoubleFilterExpression(string testCaseFilterValue, Func<Func<string, object>, bool> predicate)
+        {
+            TestCaseFilterValue = testCaseFilterValue;
+            this.predicate = predicate;
+        }
+
+        public string TestCaseFilterValue { get; }
+
+        public bool MatchTestCase(TestCase testCase, Func<string, object> propertyValueProvider)
+        {
+            return predicate.Invoke(propertyValueProvider);
+        }
+
+        public static TestDoubleFilterExpression AnyIsEqualTo(string propertyName, object value)
+        {
+            return new TestDoubleFilterExpression($"{propertyName}={value}", propertyValueProvider =>
+            {
+                var list = propertyValueProvider.Invoke(propertyName) as IEnumerable;
+                return list == null ? false : list.Cast<object>().Contains(value);
+            });
+        }
+    }
+}

--- a/src/NUnitTestAdapterTests/Filtering/VSTestFilterStringTests.cs
+++ b/src/NUnitTestAdapterTests/Filtering/VSTestFilterStringTests.cs
@@ -1,0 +1,74 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Terje Sandstrom
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
+{
+    public static class VSTestFilterStringTests
+    {
+        [TestCase(null, new[] { "NonExplicitParent.NonExplicitTest" })]
+        [TestCase("", new[] { "NonExplicitParent.NonExplicitTest" })]
+        [TestCase("TestCategory = CategoryThatMatchesNothing", new string[0])]
+        [TestCase("MeaninglessName", new string[0])]
+        [TestCase("TestCategory != CategoryThatMatchesNothing", new[] { "NonExplicitParent.NonExplicitTest" })]
+        [TestCase("TestCategory = SomeCat", new[] { "NonExplicitParent.NonExplicitTest" })]
+        [TestCase("TestCategory != SomeCat", new string[0])]
+        public static void NoFiltersIncludeExplicitTests(string vsTestFilterString, IReadOnlyCollection<string> nonExplicitTestIds)
+        {
+            var result = ApplyFilter(vsTestFilterString, @"
+                <test-suite id='1' name='NonExplicitParent' fullname='NonExplicitParent'>
+                    <test-case id='2' name='NonExplicitTest' fullname='NonExplicitParent.NonExplicitTest'>
+                        <properties>
+                            <property name='Category' value='SomeCat' />
+                        </properties>
+                    </test-case>
+                    <test-case id='3' name='ExplicitTest' fullname='NonExplicitParent.ExplicitTest' runstate='Explicit'>
+                        <properties>
+                            <property name='Category' value='SomeCat' />
+                        </properties>
+                    </test-case>
+                </test-suite>
+                <test-suite id='4' name='ExplicitParent' fullname='ExplicitParent' runstate='Explicit'>
+                    <test-case id='5' name='NonExplicitTest' fullname='ExplicitParent.NonExplicitTest'>
+                        <properties>
+                            <property name='Category' value='SomeCat' />
+                        </properties>
+                    </test-case>
+                </test-suite>");
+
+            Assert.That(from test in result select test.FullyQualifiedName, Is.EquivalentTo(nonExplicitTestIds));
+        }
+
+        private static IEnumerable<TestCase> ApplyFilter(string vsTestFilterString, string testCasesXml)
+        {
+            var filter = FilteringTestUtils.CreateTestFilter(string.IsNullOrEmpty(vsTestFilterString) ? null :
+                FilteringTestUtils.CreateVSTestFilterExpression(vsTestFilterString));
+
+            return filter.CheckFilter(FilteringTestUtils.ConvertTestCases(testCasesXml));
+        }
+    }
+}

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -68,8 +68,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             CheckTestCase(testCase);
 
             Assert.That(testConverter.TraitsCache.Keys.Count, Is.EqualTo(1));
-            Assert.That(testConverter.TraitsCache["121"].Count, Is.EqualTo(1));
-            var parentTrait = testConverter.TraitsCache["121"];
+            Assert.That(testConverter.TraitsCache["121"].Traits.Count, Is.EqualTo(1));
+            var parentTrait = testConverter.TraitsCache["121"].Traits;
             Assert.That(parentTrait[0].Name, Is.EqualTo("Category"));
             Assert.That(parentTrait[0].Value, Is.EqualTo("super"));
         }
@@ -164,33 +164,33 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(testCase.GetCategories(),Is.EquivalentTo(new [] { "super", "cat1", }));
         }
 
-        private void CheckNodesWithNoProperties(IDictionary<string, List<Trait>> traits)
+        private void CheckNodesWithNoProperties(IDictionary<string, TraitsFeature.CachedTestCaseInfo> cache)
         {
-            Assert.That(traits["2"].Count, Is.EqualTo(0));
-            Assert.That(traits["0-1010"].Count, Is.EqualTo(0));
+            Assert.That(cache["2"].Traits.Count, Is.EqualTo(0));
+            Assert.That(cache["0-1010"].Traits.Count, Is.EqualTo(0));
         }
 
-        private void CheckNoTestCaseNodesExist(IDictionary<string, List<Trait>> traits)
+        private void CheckNoTestCaseNodesExist(IDictionary<string, TraitsFeature.CachedTestCaseInfo> cache)
         {
-            Assert.That(!traits.ContainsKey("0-1008"));
-            Assert.That(!traits.ContainsKey("0-1006"));
-            Assert.That(!traits.ContainsKey("0-1004"));
-            Assert.That(!traits.ContainsKey("0-1003"));
-            Assert.That(!traits.ContainsKey("0-1001"));
+            Assert.That(!cache.ContainsKey("0-1008"));
+            Assert.That(!cache.ContainsKey("0-1006"));
+            Assert.That(!cache.ContainsKey("0-1004"));
+            Assert.That(!cache.ContainsKey("0-1003"));
+            Assert.That(!cache.ContainsKey("0-1001"));
         }
 
-        private void CheckNodeProperties(IDictionary<string, List<Trait>> traitssCache, string id, KeyValuePair<string,string>[] kps)
+        private void CheckNodeProperties(IDictionary<string, TraitsFeature.CachedTestCaseInfo> cache, string id, KeyValuePair<string,string>[] kps)
         {
-            Assert.That(traitssCache.ContainsKey(id));
-            Assert.That(traitssCache[id].Count, Is.EqualTo(kps.Count()));
-            var traits = traitssCache[id];
+            Assert.That(cache.ContainsKey(id));
+            Assert.That(cache[id].Traits.Count, Is.EqualTo(kps.Count()));
+            var info = cache[id];
 
             foreach(var kp in kps)
             {
-                Assert.That(traits.Any(t => t.Name == kp.Key && t.Value == kp.Value));
+                Assert.That(info.Traits.Any(t => t.Name == kp.Key && t.Value == kp.Value));
             }
         }
 
-      
+
     }
 }


### PR DESCRIPTION
The rest of the 3.10 work for #47.

I used a new, **non-category**, **non-trait**, separate, hidden bool TestProperty. This is cleaner than re-using the display values we put in the Category or Traits collections; otherwise, we'll detect NUnit categories or properties named Explicit as the run state when they are not, and block them too.

The last commit is the minimum possible part of the refactor https://github.com/nunit/nunit3-vs-adapter/pull/457 to remove the otherwise necessary ugly hack. I wanted to go further and do the same thing to the Category property, but that just would be starting to redo the same work in https://github.com/nunit/nunit3-vs-adapter/pull/457. I still want to do https://github.com/nunit/nunit3-vs-adapter/pull/457 ASAP post-3.10.