### PR TITLE
Copy adapter PDB to project build output

### DIFF
--- a/nuget/net35/NUnit3TestAdapter.props
+++ b/nuget/net35/NUnit3TestAdapter.props
@@ -6,6 +6,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb">
+      <Link>NUnit3.TestAdapter.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
     <Content Include="$(MSBuildThisFileDirectory)nunit.engine.dll">
       <Link>nunit.engine.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/nuget/netcoreapp1.0/NUnit3TestAdapter.props
+++ b/nuget/netcoreapp1.0/NUnit3TestAdapter.props
@@ -6,6 +6,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb">
+      <Link>NUnit3.TestAdapter.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
     <Content Include="$(MSBuildThisFileDirectory)nunit.engine.netstandard.dll">
       <Link>nunit.engine.netstandard.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
I didn't realize until too late that we are the ones responsible for copying the adapter to build output since it's not in `/lib`. This is totally my bad. I tried it on various configurations of csproj but a .NET Framework target was always the one listed first, and I should have tried it on a .NET Core-only project.

Source stepping works with no fuss for any .NET Framework project because the adapter is executed from `%temp%\VisualStudioTestExplorerExtensions\{version}` or from the VSIX installation folder, but with .NET Core, the adapter is executed from the build output folder.

Copying the PDB out beside the adapter assembly is the only way I know to allow source-stepping to work, besides telling the user to locate `%userprofile%/.nuget/packages/nunit3testadapter/{version}/build/{framework}/NUnit3.TestAdapter.pdb` themselves.

I'll update the docs with the correct workaround until the next release.