### PR TITLE
Tolerate NuGet package modified by removing PDBs

### DIFF
--- a/nuget/net35/NUnit3TestAdapter.props
+++ b/nuget/net35/NUnit3TestAdapter.props
@@ -6,7 +6,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb">
+    <Content Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb" Condition="Exists('$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb')">
       <Link>NUnit3.TestAdapter.pdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>

--- a/nuget/netcoreapp1.0/NUnit3TestAdapter.props
+++ b/nuget/netcoreapp1.0/NUnit3TestAdapter.props
@@ -6,7 +6,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb">
+    <Content Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb" Condition="Exists('$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb')">
       <Link>NUnit3.TestAdapter.pdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>


### PR DESCRIPTION
Fixes #490 

Tested by creating a project with a package reference to NUnit3TestAdapter 3.10, deleting the PDB from `%userprofile%\.nuget\packages\nunit3testadapter\3.10.0\build\net35\NUnit3.TestAdapter.pdb`, verifying that the build failed, and making the same change in this PR to
`%userprofile%\.nuget\packages\nunit3testadapter\3.10.0\build\net35\NUnit3TestAdapter.props` and verifying that the build succeeded.

And deleting `%userprofile%\.nuget\packages\nunit3testadapter\3.10.0` afterwards. 😊