### PR TITLE
Adding Category Filter for Category Trait

### DIFF
--- a/src/NUnitTestAdapter/TfsTestFilter.cs
+++ b/src/NUnitTestAdapter/TfsTestFilter.cs
@@ -60,12 +60,14 @@ namespace NUnit.VisualStudio.TestAdapter
             SupportedPropertiesCache["FullyQualifiedName"] = TestCaseProperties.FullyQualifiedName;
             SupportedPropertiesCache["Name"] = TestCaseProperties.DisplayName;
             SupportedPropertiesCache["TestCategory"] = CategoryList.NUnitTestCategoryProperty;
+            SupportedPropertiesCache["Category"] = CategoryList.NUnitTestCategoryProperty;
             // Initialize the trait cache
             var priorityTrait = new NTrait("Priority", "");
             var categoryTrait = new NTrait("Category", "");
             SupportedTraitCache = new Dictionary<string, NTrait>(StringComparer.OrdinalIgnoreCase);
             SupportedTraitCache["Priority"] = priorityTrait;
             SupportedTraitCache["TestCategory"] = categoryTrait;
+            SupportedTraitCache["Category"] = categoryTrait;
             // Initialize the trait property map, since TFS doesnt know about traits
             TraitPropertyMap = new Dictionary<NTrait, TestProperty>(new NTraitNameComparer());
             var priorityProperty = TestProperty.Find("Priority") ??

--- a/src/NUnitTestAdapterTests/Filtering/TestFilterTests.cs
+++ b/src/NUnitTestAdapterTests/Filtering/TestFilterTests.cs
@@ -40,6 +40,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
             Assert.NotNull(prop);
             prop = TfsTestFilter.PropertyProvider("TestCategory");
             Assert.NotNull(prop);
+            prop = TfsTestFilter.PropertyProvider("Category");
+            Assert.NotNull(prop);
         }
 
         [Test]
@@ -47,6 +49,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
         {
             var testFilter = new TfsTestFilter(null);
             var trait = TfsTestFilter.TraitProvider("TestCategory");
+            Assert.NotNull(trait);
+            trait = TfsTestFilter.TraitProvider("Category");
             Assert.NotNull(trait);
         }
 
@@ -68,7 +72,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
         }
 
         [Test]
-        public void PropertyValueProviderCategoryWithOneCategory()
+        public void PropertyValueProviderWithOneCategoryAndTestCategoryAsFilter()
         {
             var tc = new TestCase("Test1", new Uri("executor://NUnitTestExecutor"), "NUnit.VSIX");
             tc.AddTrait("Category", "CI");
@@ -78,7 +82,17 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
         }
 
         [Test]
-        public void PropertyValueProviderCategoryWithNoTraits()
+        public void PropertyValueProviderWithOneCategoryAndCategoryAsFilter()
+        {
+            var tc = new TestCase("Test1", new Uri("executor://NUnitTestExecutor"), "NUnit.VSIX");
+            tc.AddTrait("Category", "CI");
+            var testFilter = new TfsTestFilter(null);
+            var obj = TfsTestFilter.PropertyValueProvider(tc, "Category");
+            Assert.AreSame("CI", obj);
+        }
+
+        [Test]
+        public void PropertyValueProviderWithNoTraitsAndTestCategoryAsFilter()
         {
             var tc = new TestCase("Test1", new Uri("executor://NUnitTestExecutor"), "NUnit.VSIX");
             var testFilter = new TfsTestFilter(null);
@@ -87,7 +101,16 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
         }
 
         [Test]
-        public void PropertyValueProviderCategoryWithMultipleCategories()
+        public void PropertyValueProviderWithNoTraitsAndCategoryAsFilter()
+        {
+            var tc = new TestCase("Test1", new Uri("executor://NUnitTestExecutor"), "NUnit.VSIX");
+            var testFilter = new TfsTestFilter(null);
+            var obj = TfsTestFilter.PropertyValueProvider(tc, "Category");
+            Assert.IsNull(obj);
+        }
+
+        [Test]
+        public void PropertyValueProviderWithMultipleCategoriesAndTestCategoryAsFilter()
         {
             var tc = new TestCase("Test1", new Uri("executor://NUnitTestExecutor"), "NUnit.VSIX");
             tc.AddTrait("Category", "CI");
@@ -98,6 +121,20 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
             Assert.AreEqual(obj.Length,2);
             Assert.AreSame("CI", obj[0]);
             Assert.AreSame("MyOwn",obj[1]);
+        }
+
+        [Test]
+        public void PropertyValueProviderWithMultipleCategoriesAndCategoryAsFilter()
+        {
+            var tc = new TestCase("Test1", new Uri("executor://NUnitTestExecutor"), "NUnit.VSIX");
+            tc.AddTrait("Category", "CI");
+            tc.AddTrait("Category", "MyOwn");
+            var testFilter = new TfsTestFilter(null);
+            var obj = TfsTestFilter.PropertyValueProvider(tc, "Category") as string[];
+            Assert.IsNotNull(obj);
+            Assert.AreEqual(obj.Length, 2);
+            Assert.AreSame("CI", obj[0]);
+            Assert.AreSame("MyOwn", obj[1]);
         }
 
         [Test]
@@ -121,10 +158,28 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
         [TestCase("NS11", new[] { "nUnitClassLibrary.NestedClasses.NC11" })]
         [TestCase("NS2", new[] { "nUnitClassLibrary.NestedClasses+NestedClass2.NC21" })]
         [TestCase("NS21", new[] { "nUnitClassLibrary.NestedClasses+NestedClass2.NC21" })]
-        public static void CanFilterConvertedTestsByCategory(string category, IReadOnlyCollection<string> expectedMatchingTestNames)
+        public void CanFilterConvertedTestsByCategoryWithTestCategoryAsFilter(string category, IReadOnlyCollection<string> expectedMatchingTestNames)
         {
             FilteringTestUtils.AssertExpectedResult(
                 TestDoubleFilterExpression.AnyIsEqualTo("TestCategory", category),
+                FilteringTestUtils.ConvertTestCases(FakeTestData.HierarchyTestXml),
+                expectedMatchingTestNames);
+        }
+
+        [TestCase("CategoryThatMatchesNothing", new string[0])]
+        [TestCase("AsmCat", new[] { "nUnitClassLibrary.Class1.nUnitTest", "nUnitClassLibrary.ClassD.dNunitTest", "nUnitClassLibrary.ClassD.nUnitTest", "nUnitClassLibrary.NestedClasses.NC11", "nUnitClassLibrary.NestedClasses+NestedClass2.NC21" })]
+        [TestCase("BaseClass", new[] { "nUnitClassLibrary.Class1.nUnitTest", "nUnitClassLibrary.ClassD.dNunitTest", "nUnitClassLibrary.ClassD.nUnitTest" })]
+        [TestCase("Base", new[] { "nUnitClassLibrary.Class1.nUnitTest", "nUnitClassLibrary.ClassD.nUnitTest" })]
+        [TestCase("DerivedClass", new[] { "nUnitClassLibrary.ClassD.dNunitTest", "nUnitClassLibrary.ClassD.nUnitTest" })]
+        [TestCase("Derived", new[] { "nUnitClassLibrary.ClassD.dNunitTest" })]
+        [TestCase("NS1", new[] { "nUnitClassLibrary.NestedClasses.NC11" })]
+        [TestCase("NS11", new[] { "nUnitClassLibrary.NestedClasses.NC11" })]
+        [TestCase("NS2", new[] { "nUnitClassLibrary.NestedClasses+NestedClass2.NC21" })]
+        [TestCase("NS21", new[] { "nUnitClassLibrary.NestedClasses+NestedClass2.NC21" })]
+        public void CanFilterConvertedTestsByCategoryWithCategoryAsFilter(string category, IReadOnlyCollection<string> expectedMatchingTestNames)
+        {
+            FilteringTestUtils.AssertExpectedResult(
+                TestDoubleFilterExpression.AnyIsEqualTo("Category", category),
                 FilteringTestUtils.ConvertTestCases(FakeTestData.HierarchyTestXml),
                 expectedMatchingTestNames);
         }


### PR DESCRIPTION
## Description
We can pass filters using `/TestCaseFilters` argument while running tests from command line (vstest.console.exe).

NUnit understands `TestCategory `as a filter but not `Category`.
Example: `/TestCaseFilter:TestCategory=SampleValue` works but `/TestCaseFilter:Category=SampleValue` doesn't work.

Internally NUnit maps `TestCategory` filter to `Category` trait.
So while writing test, user needs to write Category trait but while running tests user needs to pass TestCategory as filter.
Example:
```
        While writing: 

        [TestCase]
        [Category("SampleValue")]
        public void TestMethod1()
        {
            Assert.AreEqual(30, 30);
        }
       
        While testing:
        vstest.console.exe NUnitTestProject.dll /TestCaseFilter:TestCategory=SampleValue
```

## Issue
While running NUnit tests from [vstest task](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/VsTest), we can run tests in:
1. Single agent i.e. non-distributed flow
2. Multiple agents i.e. distributed flow
3. Test run with TIA (test impact analysis) as true

For 2nd and 3rd scenario, there comes a requirement in which tests needs to be filtered out at discovery time. As discovery time filtering was not supported for adapters till now (its [supported](https://github.com/Microsoft/vstest/pull/1074) now), TestPlatform filters tests at discovery on its own for these scenarios. 

While doing filtering at discovery time, TestPlatform has exact mapping of Filters to attributes. i.e. For Category attribute, Category filters is understood.

Thus behavior change in TestPlatform side filtering(understand Category filter for Category attribute) and adapter side filtering(understand TestCategory filter for Category attribute) forces users to use
1. TestCategory as filter for running test in single agent (as discovery time filtering is not done by TestPlatform here. Filtering is done by NUnit adapter at execution time)
2. Category as filter for running tests in multiple agents or when TIA is enabled. (as discovery time filtering is done by TestPlatform here)

## Solution
Adding Category filter in NUnit adapter as well. Now both Category and TestCategory filters will be understood by NUnit and will be internally mapped to Category attribute.

So now users can pass either Category or TestCategory and both will work.

## Note
I am planning to add discovery time filtering as well in near future. I will get back soon with that PR as well.


