### PR TITLE
Now using fullname (full test namespace)

### DIFF
--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -144,7 +144,7 @@ namespace NUnit.VisualStudio.TestAdapter
                                      new Uri(NUnitTestAdapter.ExecutorUri),
                                      _sourceAssembly)
             {
-                DisplayName = testNode.GetAttribute("name"),
+                DisplayName = testNode.GetAttribute("fullname"),
                 CodeFilePath = null,
                 LineNumber = 0
             };

--- a/src/NUnitTestAdapterTests/Fakes/FakeTestData.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeTestData.cs
@@ -120,7 +120,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
         public const string ResultXml =
             @"<test-suite
                 id='121'
-                name='FakeTestData'
+                name='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData.FakeTestCase'
                 fullname='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData'
                 classname='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData'>
                 <properties>
@@ -146,7 +146,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
                 </test-case>
             </test-suite>";
 
-        public const string DisplayName = "FakeTestCase";
+        public const string DisplayName = "NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData.FakeTestCase";
 
         public const string FullyQualifiedName = "NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData.FakeTestCase";
 

--- a/src/NUnitTestAdapterTests/IssueNo24Tests.cs
+++ b/src/NUnitTestAdapterTests/IssueNo24Tests.cs
@@ -10,7 +10,6 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 {
     [Explicit]
     [TestFixture]
-    [Ignore("Temporary disabled...")]
     [Category("LongRunning")]
     class IssueNo24Tests
     {

--- a/src/NUnitTestAdapterTests/IssueNo24Tests.cs
+++ b/src/NUnitTestAdapterTests/IssueNo24Tests.cs
@@ -10,6 +10,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 {
     [Explicit]
     [TestFixture]
+    [Ignore("Temporary disabled...")]
     [Category("LongRunning")]
     class IssueNo24Tests
     {

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -86,10 +87,10 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(TestCases.Count, Is.EqualTo(NUnit.Tests.Assemblies.MockAssembly.Tests));
         }
 
-        [TestCase("MockTest3", "NUnit.Tests.Assemblies.MockTestFixture.MockTest3")]
-        [TestCase("MockTest4", "NUnit.Tests.Assemblies.MockTestFixture.MockTest4")]
-        [TestCase("ExplicitlyRunTest", "NUnit.Tests.Assemblies.MockTestFixture.ExplicitlyRunTest")]
-        [TestCase("MethodWithParameters(9,11)", "NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)")]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.MockTest3", "NUnit.Tests.Assemblies.MockTestFixture.MockTest3")]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.MockTest4", "NUnit.Tests.Assemblies.MockTestFixture.MockTest4")]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.ExplicitlyRunTest", "NUnit.Tests.Assemblies.MockTestFixture.ExplicitlyRunTest")]
+        [TestCase("NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)", "NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)")]
         public void VerifyTestCaseIsFound(string name, string fullName)
         {
             var testCase = TestCases.Find(tc => tc.DisplayName == name);
@@ -97,9 +98,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         }
 
         [Category("Navigation")]
-        [TestCase("NestedClassTest1")] // parent
-        [TestCase("NestedClassTest2")] // child
-        [TestCase("NestedClassTest3")] // grandchild
+        [TestCase("NUnit.Tests.ParentClass.NestedClassTest1")] // parent
+        [TestCase("NUnit.Tests.ParentClass+ChildClass.NestedClassTest2")] // child
+        [TestCase("NUnit.Tests.ParentClass+ChildClass+GrandChildClass.NestedClassTest3")] // grandchild
         public void VerifyNestedTestCaseSourceIsAvailable(string name)
         {
             var testCase = TestCases.Find(tc => tc.DisplayName == name);

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -130,15 +130,15 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 .Count(e => e.EventType == FakeFrameworkHandle.EventType.RecordResult && e.TestResult.Outcome == outcome);
         }
 
-        [TestCase("MockTest3", TestOutcome.Passed, "Succeeded!", false)]
-        [TestCase("FailingTest", TestOutcome.Failed, "Intentional failure", true)]
-        [TestCase("TestWithException", TestOutcome.Failed, "System.Exception : Intentional Exception", true)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.MockTest3", TestOutcome.Passed, "Succeeded!", false)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.FailingTest", TestOutcome.Failed, "Intentional failure", true)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.TestWithException", TestOutcome.Failed, "System.Exception : Intentional Exception", true)]
         // NOTE: Should Inconclusive be reported as TestOutcome.None?
-        [TestCase("ExplicitlyRunTest", TestOutcome.None, null, false)]
-        [TestCase("InconclusiveTest", TestOutcome.None, "No valid data", false)]
-        [TestCase("MockTest4", TestOutcome.Skipped, "ignoring this test method for now", false)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.ExplicitlyRunTest", TestOutcome.None, null, false)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.InconclusiveTest", TestOutcome.None, "No valid data", false)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.MockTest4", TestOutcome.Skipped, "ignoring this test method for now", false)]
         // NOTE: Should this be failed?
-        [TestCase("NotRunnableTest", TestOutcome.Failed, "No arguments were provided", false)]
+        [TestCase("NUnit.Tests.Assemblies.MockTestFixture.NotRunnableTest", TestOutcome.Failed, "No arguments were provided", false)]
         public void TestResultIsReportedCorrectly(string name, TestOutcome outcome, string message, bool hasStackTrace)
         {
             var testResult = GetTestResult(name);
@@ -153,7 +153,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [Test]
         public void AttachmentsShowSupportMultipleFiles()
         {
-            var test = GetTestResult(nameof(FixtureWithAttachment.AttachmentTest));
+            var test = GetTestResult(typeof(FixtureWithAttachment).FullName + ".AttachmentTest");
             Assert.That(test, Is.Not.Null, "Could not find test result");
 
             Assert.That(test.Attachments.Count, Is.EqualTo(1));
@@ -178,12 +178,12 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         /// <summary>
         /// Tries to get the <see cref="TestResult"/> with the specified DisplayName
         /// </summary>
-        /// <param name="displayName">DisplayName to search for</param>
+        /// <param name="fullyQualifiedName">DisplayName to search for</param>
         /// <returns>The first testresult with the specified DisplayName, or <c>null</c> if none where found</returns>
-        private TestResult GetTestResult(string displayName)
+        private TestResult GetTestResult(string fullyQualifiedName)
         {
             return testLog.Events
-                            .Where(e => e.EventType == FakeFrameworkHandle.EventType.RecordResult && e.TestResult.TestCase.DisplayName == displayName)
+                            .Where(e => e.EventType == FakeFrameworkHandle.EventType.RecordResult && e.TestResult.TestCase.FullyQualifiedName == fullyQualifiedName)
                             .Select(e => e.TestResult)
                             .FirstOrDefault();
         }

--- a/src/NUnitTestAdapterTests/TraitsTests.cs
+++ b/src/NUnitTestAdapterTests/TraitsTests.cs
@@ -15,7 +15,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         const string TestXml =
    @"<test-suite
                 id='121'
-                name='FakeTestData'
+                name='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData'
                 fullname='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData'
                 classname='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData'>
                 <properties>
@@ -23,7 +23,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 </properties>
                 <test-case
                     id='123' 
-                    name='FakeTestCase'
+                    name='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData.FakeTestCase'
                     fullname='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData.FakeTestCase'
                     methodname='FakeTestCase'
                     classname='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData'>
@@ -55,34 +55,34 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         ///    { }
         ///}
         /// </summary>
-        const string XmlHierarchyOfClasses = @"<test-run id='2' name='nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' testcasecount='5'>
-	<test-suite type='Assembly' id='0-1009' name='nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' runstate='Runnable' testcasecount='5'>
+        const string XmlHierarchyOfClasses = @"<test-run id='2' name='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' testcasecount='5'>
+	<test-suite type='Assembly' id='0-1009' name='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' runstate='Runnable' testcasecount='5'>
 		<properties>
 			<property name='_PID' value='6164' />
 			<property name='_APPDOMAIN' value='domain-71b2ab93-nUnitClassLibrary.dll' />
 		</properties>
 		<test-suite type='TestSuite' id='0-1010' name='nUnitClassLibrary' fullname='nUnitClassLibrary' runstate='Runnable' testcasecount='5'>
-			<test-suite type='TestFixture' id='0-1000' name='Class1' fullname='nUnitClassLibrary.Class1' classname='nUnitClassLibrary.Class1' runstate='Runnable' testcasecount='1'>
+			<test-suite type='TestFixture' id='0-1000' name='nUnitClassLibrary.Class1' fullname='nUnitClassLibrary.Class1' classname='nUnitClassLibrary.Class1' runstate='Runnable' testcasecount='1'>
 				<properties>
 					<property name='Category' value='BaseClass' />
 				</properties>
-				<test-case id='0-1001' name='nUnitTest' fullname='nUnitClassLibrary.Class1.nUnitTest' methodname='nUnitTest' classname='nUnitClassLibrary.Class1' runstate='Runnable' seed='113395783'>
+				<test-case id='0-1001' name='nUnitClassLibrary.Class1.nUnitTest' fullname='nUnitClassLibrary.Class1.nUnitTest' methodname='nUnitTest' classname='nUnitClassLibrary.Class1' runstate='Runnable' seed='113395783'>
 					<properties>
 						<property name='Category' value='Base' />
 					</properties>
 				</test-case>
 			</test-suite>
-			<test-suite type='TestFixture' id='0-1002' name='ClassD' fullname='nUnitClassLibrary.ClassD' classname='nUnitClassLibrary.ClassD' runstate='Runnable' testcasecount='2'>
+			<test-suite type='TestFixture' id='0-1002' name='nUnitClassLibrary.ClassD' fullname='nUnitClassLibrary.ClassD' classname='nUnitClassLibrary.ClassD' runstate='Runnable' testcasecount='2'>
 				<properties>
 					<property name='Category' value='DerivedClass' />
 					<property name='Category' value='BaseClass' />
 				</properties>
-				<test-case id='0-1003' name='dNunitTest' fullname='nUnitClassLibrary.ClassD.dNunitTest' methodname='dNunitTest' classname='nUnitClassLibrary.ClassD' runstate='Runnable' seed='405714082'>
+				<test-case id='0-1003' name='nUnitClassLibrary.ClassD.dNunitTest' fullname='nUnitClassLibrary.ClassD.dNunitTest' methodname='dNunitTest' classname='nUnitClassLibrary.ClassD' runstate='Runnable' seed='405714082'>
 					<properties>
 						<property name='Category' value='Derived' />
 					</properties>
 				</test-case>
-				<test-case id='0-1004' name='nUnitTest' fullname='nUnitClassLibrary.ClassD.nUnitTest' methodname='nUnitTest' classname='nUnitClassLibrary.Class1' runstate='Runnable' seed='1553985978'>
+				<test-case id='0-1004' name='nUnitClassLibrary.ClassD.nUnitTest' fullname='nUnitClassLibrary.ClassD.nUnitTest' methodname='nUnitTest' classname='nUnitClassLibrary.Class1' runstate='Runnable' seed='1553985978'>
 					<properties>
 						<property name='Category' value='Base' />
 					</properties>
@@ -113,28 +113,28 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         ///    }
         ///}
         /// </summary>
-        const string XmlNestedClasses = @"<test-run id='2' name='nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' testcasecount='5'>
-	<test-suite type='Assembly' id='0-1009' name='nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' runstate='Runnable' testcasecount='5'>
+        const string XmlNestedClasses = @"<test-run id='2' name='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' testcasecount='5'>
+	<test-suite type='Assembly' id='0-1009' name='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' runstate='Runnable' testcasecount='5'>
 		<properties>
 			<property name='_PID' value='6164' />
 			<property name='_APPDOMAIN' value='domain-71b2ab93-nUnitClassLibrary.dll' />
 		</properties>
 		<test-suite type='TestSuite' id='0-1010' name='nUnitClassLibrary' fullname='nUnitClassLibrary' runstate='Runnable' testcasecount='5'>
-			<test-suite type='TestFixture' id='0-1005' name='NestedClasses' fullname='nUnitClassLibrary.NestedClasses' classname='nUnitClassLibrary.NestedClasses' runstate='Runnable' testcasecount='1'>
+			<test-suite type='TestFixture' id='0-1005' name='nUnitClassLibrary.NestedClasses' fullname='nUnitClassLibrary.NestedClasses' classname='nUnitClassLibrary.NestedClasses' runstate='Runnable' testcasecount='1'>
 				<properties>
 					<property name='Category' value='NS1' />
 				</properties>
-				<test-case id='0-1006' name='NC11' fullname='nUnitClassLibrary.NestedClasses.NC11' methodname='NC11' classname='nUnitClassLibrary.NestedClasses' runstate='Runnable' seed='1107340752'>
+				<test-case id='0-1006' name='nUnitClassLibrary.NestedClasses.NC11' fullname='nUnitClassLibrary.NestedClasses.NC11' methodname='NC11' classname='nUnitClassLibrary.NestedClasses' runstate='Runnable' seed='1107340752'>
 					<properties>
 						<property name='Category' value='NS11' />
 					</properties>
 				</test-case>
 			</test-suite>
-			<test-suite type='TestFixture' id='0-1007' name='NestedClasses+NestedClass2' fullname='nUnitClassLibrary.NestedClasses+NestedClass2' classname='nUnitClassLibrary.NestedClasses+NestedClass2' runstate='Runnable' testcasecount='1'>
+			<test-suite type='TestFixture' id='0-1007' name='nUnitClassLibrary.NestedClasses+NestedClass2' fullname='nUnitClassLibrary.NestedClasses+NestedClass2' classname='nUnitClassLibrary.NestedClasses+NestedClass2' runstate='Runnable' testcasecount='1'>
 				<properties>
 					<property name='Category' value='NS2' />
 				</properties>
-				<test-case id='0-1008' name='NC21' fullname='nUnitClassLibrary.NestedClasses+NestedClass2.NC21' methodname='NC21' classname='nUnitClassLibrary.NestedClasses+NestedClass2' runstate='Runnable' seed='1823789309'>
+				<test-case id='0-1008' name='nUnitClassLibrary.NestedClasses+NestedClass2.NC21' fullname='nUnitClassLibrary.NestedClasses+NestedClass2.NC21' methodname='NC21' classname='nUnitClassLibrary.NestedClasses+NestedClass2' runstate='Runnable' seed='1823789309'>
 					<properties>
 						<property name='Category' value='NS21' />
 					</properties>
@@ -158,23 +158,23 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         ///}
         /// </summary>
         const string TestXmlParametrizedData =
-            @"<test-suite type='Assembly' id='4-1004' name='ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='2'>
+            @"<test-suite type='Assembly' id='4-1004' name='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='2'>
     <properties>
         <property name='_PID' value='10904' />
         <property name='_APPDOMAIN' value='domain-aa3de7f5-ClassLibrary11.dll' />
     </properties>
     <test-suite type='TestSuite' id='4-1005' name='ClassLibrary11' fullname='ClassLibrary11' runstate='Runnable' testcasecount='2'>
-        <test-suite type='TestFixture' id='4-1000' name='ManyTests' fullname='ClassLibrary11.ManyTests' classname='ClassLibrary11.ManyTests' runstate='Runnable' testcasecount='2'>
+        <test-suite type='TestFixture' id='4-1000' name='ClassLibrary11.ManyTests' fullname='ClassLibrary11.ManyTests' classname='ClassLibrary11.ManyTests' runstate='Runnable' testcasecount='2'>
             <properties>
                 <property name='Category' value='ClassLevel' />
             </properties>
-            <test-suite type='ParameterizedMethod' id='4-1003' name='ThatWeExist' fullname='ClassLibrary11.ManyTests.ThatWeExist' classname='ClassLibrary11.ManyTests' runstate='Runnable' testcasecount='2'>
+            <test-suite type='ParameterizedMethod' id='4-1003' name='ClassLibrary11.ManyTests.ThatWeExist' fullname='ClassLibrary11.ManyTests.ThatWeExist' classname='ClassLibrary11.ManyTests' runstate='Runnable' testcasecount='2'>
                 <properties>
                     <property name='Category' value='TestCase level' />
                     <property name='Category' value='MethodLevel' />
                 </properties>
-                <test-case id='4-1001' name='ThatWeExist(1)' fullname='ClassLibrary11.ManyTests.ThatWeExist(1)' methodname='ThatWeExist' classname='ClassLibrary11.ManyTests' runstate='Runnable' seed='1087191830' />
-                <test-case id='4-1002' name='ThatWeExist(2)' fullname='ClassLibrary11.ManyTests.ThatWeExist(2)' methodname='ThatWeExist' classname='ClassLibrary11.ManyTests' runstate='Runnable' seed='1855643337' />
+                <test-case id='4-1001' name='ClassLibrary11.ManyTests.ThatWeExist(1)' fullname='ClassLibrary11.ManyTests.ThatWeExist(1)' methodname='ThatWeExist' classname='ClassLibrary11.ManyTests' runstate='Runnable' seed='1087191830' />
+                <test-case id='4-1002' name='ClassLibrary11.ManyTests.ThatWeExist(2)' fullname='ClassLibrary11.ManyTests.ThatWeExist(2)' methodname='ThatWeExist' classname='ClassLibrary11.ManyTests' runstate='Runnable' seed='1855643337' />
             </test-suite>
         </test-suite>
     </test-suite>
@@ -193,17 +193,17 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         ///}
         /// </summary>
         private const string TestXmlStandardClass =
-            @"<test-suite type='Assembly' id='5-1002' name='ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='1'>
+            @"<test-suite type='Assembly' id='5-1002' name='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='1'>
     <properties>
         <property name='_PID' value='10904' />
         <property name='_APPDOMAIN' value='domain-aa3de7f5-ClassLibrary11.dll' />
     </properties>
     <test-suite type='TestSuite' id='5-1003' name='ClassLibrary11' fullname='ClassLibrary11' runstate='Runnable' testcasecount='1'>
-        <test-suite type='TestFixture' id='5-1000' name='StandardClass' fullname='ClassLibrary11.StandardClass' classname='ClassLibrary11.StandardClass' runstate='Runnable' testcasecount='1'>
+        <test-suite type='TestFixture' id='5-1000' name='ClassLibrary11.StandardClass' fullname='ClassLibrary11.StandardClass' classname='ClassLibrary11.StandardClass' runstate='Runnable' testcasecount='1'>
             <properties>
                 <property name='Category' value='ClassLevel' />
             </properties>
-            <test-case id='5-1001' name='ThatWeExist' fullname='ClassLibrary11.StandardClass.ThatWeExist' methodname='ThatWeExist' classname='ClassLibrary11.StandardClass' runstate='Runnable' seed='1462235782'>
+            <test-case id='5-1001' name='ClassLibrary11.StandardClass.ThatWeExist' fullname='ClassLibrary11.StandardClass.ThatWeExist' methodname='ThatWeExist' classname='ClassLibrary11.StandardClass' runstate='Runnable' seed='1462235782'>
                 <properties>
                     <property name='Category' value='MethodLevel' />
                 </properties>
@@ -228,21 +228,21 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         ///}
         /// </summary>
         private const string TestCaseWithCategory =
-            @"<test-suite type='Assembly' id='3-1005' name='ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='3'>
+            @"<test-suite type='Assembly' id='3-1005' name='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='3'>
    <properties>
       <property name='_PID' value='23304' />
       <property name='_APPDOMAIN' value='domain-aa3de7f5-ClassLibrary11.dll' />
    </properties>
    <test-suite type='TestSuite' id='3-1006' name='ClassLibrary11' fullname='ClassLibrary11' runstate='Runnable' testcasecount='3'>
-      <test-suite type='TestFixture' id='3-1000' name='Class1' fullname='ClassLibrary11.Class1' classname='ClassLibrary11.Class1' runstate='Runnable' testcasecount='3'>
-         <test-suite type='ParameterizedMethod' id='3-1004' name='SumTests' fullname='ClassLibrary11.Class1.SumTests' classname='ClassLibrary11.Class1' runstate='Runnable' testcasecount='3'>
-            <test-case id='3-1001' name='SumTests(1,2)' fullname='ClassLibrary11.Class1.SumTests(1,2)' methodname='SumTests' classname='ClassLibrary11.Class1' runstate='Runnable' seed='433189107'>
+      <test-suite type='TestFixture' id='3-1000' name='ClassLibrary11.Class1' fullname='ClassLibrary11.Class1' classname='ClassLibrary11.Class1' runstate='Runnable' testcasecount='3'>
+         <test-suite type='ParameterizedMethod' id='3-1004' name='ClassLibrary11.Class1.SumTests' fullname='ClassLibrary11.Class1.SumTests' classname='ClassLibrary11.Class1' runstate='Runnable' testcasecount='3'>
+            <test-case id='3-1001' name='ClassLibrary11.Class1.SumTests(1,2)' fullname='ClassLibrary11.Class1.SumTests(1,2)' methodname='SumTests' classname='ClassLibrary11.Class1' runstate='Runnable' seed='433189107'>
                <properties>
                   <property name='Category' value='Single' />
                </properties>
             </test-case>
-            <test-case id='3-1002' name='SumTests(4,5)' fullname='ClassLibrary11.Class1.SumTests(4,5)' methodname='SumTests' classname='ClassLibrary11.Class1' runstate='Runnable' seed='1896735603' />
-            <test-case id='3-1003' name='SumTests(27,30)' fullname='ClassLibrary11.Class1.SumTests(27,30)' methodname='SumTests' classname='ClassLibrary11.Class1' runstate='Runnable' seed='225813975' />
+            <test-case id='3-1002' name='ClassLibrary11.Class1.SumTests(4,5)' fullname='ClassLibrary11.Class1.SumTests(4,5)' methodname='SumTests' classname='ClassLibrary11.Class1' runstate='Runnable' seed='1896735603' />
+            <test-case id='3-1003' name='ClassLibrary11.Class1.SumTests(27,30)' fullname='ClassLibrary11.Class1.SumTests(27,30)' methodname='SumTests' classname='ClassLibrary11.Class1' runstate='Runnable' seed='225813975' />
          </test-suite>
       </test-suite>
    </test-suite>
@@ -269,33 +269,33 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         ///    }
         ///}
         private const string TestCaseWithInheritedTestsInSameAssembly =
-            @"<test-suite type='Assembly' id='0-1005' name='ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='3'>
+            @"<test-suite type='Assembly' id='0-1005' name='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='3'>
       <properties>
          <property name='_PID' value='27456' />
          <property name='_APPDOMAIN' value='domain-aa3de7f5-ClassLibrary11.dll' />
       </properties>
       <test-suite type='TestSuite' id='0-1006' name='ClassLibrary11' fullname='ClassLibrary11' runstate='Runnable' testcasecount='3'>
-         <test-suite type='TestFixture' id='0-1002' name='Derived' fullname='ClassLibrary11.Derived' classname='ClassLibrary11.Derived' runstate='Runnable' testcasecount='2'>
+         <test-suite type='TestFixture' id='0-1002' name='ClassLibrary11.Derived' fullname='ClassLibrary11.Derived' classname='ClassLibrary11.Derived' runstate='Runnable' testcasecount='2'>
             <properties>
                <property name='Category' value='DerivedClass' />
                <property name='Category' value='BaseClass' />
             </properties>
-            <test-case id='0-1004' name='TestItBase' fullname='ClassLibrary11.Derived.TestItBase' methodname='TestItBase' classname='ClassLibrary11.TestBase' runstate='Runnable' seed='1107082401'>
+            <test-case id='0-1004' name='ClassLibrary11.Derived.TestItBase' fullname='ClassLibrary11.Derived.TestItBase' methodname='TestItBase' classname='ClassLibrary11.TestBase' runstate='Runnable' seed='1107082401'>
                <properties>
                   <property name='Category' value='BaseMethod' />
                </properties>
             </test-case>
-            <test-case id='0-1003' name='TestItDerived' fullname='ClassLibrary11.Derived.TestItDerived' methodname='TestItDerived' classname='ClassLibrary11.Derived' runstate='Runnable' seed='1484432600'>
+            <test-case id='0-1003' name='ClassLibrary11.Derived.TestItDerived' fullname='ClassLibrary11.Derived.TestItDerived' methodname='TestItDerived' classname='ClassLibrary11.Derived' runstate='Runnable' seed='1484432600'>
                <properties>
                   <property name='Category' value='DerivedMethod' />
                </properties>
             </test-case>
          </test-suite>
-         <test-suite type='TestFixture' id='0-1000' name='TestBase' fullname='ClassLibrary11.TestBase' classname='ClassLibrary11.TestBase' runstate='Runnable' testcasecount='1'>
+         <test-suite type='TestFixture' id='0-1000' name='ClassLibrary11.TestBase' fullname='ClassLibrary11.TestBase' classname='ClassLibrary11.TestBase' runstate='Runnable' testcasecount='1'>
             <properties>
                <property name='Category' value='BaseClass' />
             </properties>
-            <test-case id='0-1001' name='TestItBase' fullname='ClassLibrary11.TestBase.TestItBase' methodname='TestItBase' classname='ClassLibrary11.TestBase' runstate='Runnable' seed='144634857'>
+            <test-case id='0-1001' name='ClassLibrary11.TestBase.TestItBase' fullname='ClassLibrary11.TestBase.TestItBase' methodname='TestItBase' classname='ClassLibrary11.TestBase' runstate='Runnable' seed='144634857'>
                <properties>
                   <property name='Category' value='BaseMethod' />
                </properties>
@@ -325,23 +325,23 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         ///    }
         ///}
         private const string TestCaseWithAbstractInheritedTestsInSameAssembly =
-            @"<test-suite type='Assembly' id='0-1003' name='ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='2'>
+            @"<test-suite type='Assembly' id='0-1003' name='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' fullname='C:\Users\Terje\documents\visual studio 2017\Projects\ClassLibrary11\ClassLibrary11\bin\Debug\ClassLibrary11.dll' runstate='Runnable' testcasecount='2'>
       <properties>
          <property name='_PID' value='47684' />
          <property name='_APPDOMAIN' value='domain-aa3de7f5-ClassLibrary11.dll' />
       </properties>
       <test-suite type='TestSuite' id='0-1004' name='ClassLibrary11' fullname='ClassLibrary11' runstate='Runnable' testcasecount='2'>
-         <test-suite type='TestFixture' id='0-1000' name='Derived' fullname='ClassLibrary11.Derived' classname='ClassLibrary11.Derived' runstate='Runnable' testcasecount='2'>
+         <test-suite type='TestFixture' id='0-1000' name='ClassLibrary11.Derived' fullname='ClassLibrary11.Derived' classname='ClassLibrary11.Derived' runstate='Runnable' testcasecount='2'>
             <properties>
                <property name='Category' value='DerivedClass' />
                <property name='Category' value='BaseClass' />
             </properties>
-            <test-case id='0-1002' name='TestItBase' fullname='ClassLibrary11.Derived.TestItBase' methodname='TestItBase' classname='ClassLibrary11.TestBase' runstate='Runnable' seed='1628925226'>
+            <test-case id='0-1002' name='ClassLibrary11.Derived.TestItBase' fullname='ClassLibrary11.Derived.TestItBase' methodname='TestItBase' classname='ClassLibrary11.TestBase' runstate='Runnable' seed='1628925226'>
                <properties>
                   <property name='Category' value='BaseMethod' />
                </properties>
             </test-case>
-            <test-case id='0-1001' name='TestItDerived' fullname='ClassLibrary11.Derived.TestItDerived' methodname='TestItDerived' classname='ClassLibrary11.Derived' runstate='Runnable' seed='1596181992'>
+            <test-case id='0-1001' name='ClassLibrary11.Derived.TestItDerived' fullname='ClassLibrary11.Derived.TestItDerived' methodname='TestItDerived' classname='ClassLibrary11.Derived' runstate='Runnable' seed='1596181992'>
                <properties>
                   <property name='Category' value='DerivedMethod' />
                </properties>
@@ -401,11 +401,11 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             ProcessXml2TestCase(xml);
 
             Assert.That(testcaselist.Count, Is.EqualTo(2), "Wrong number of testcases found");
-            var testcase1 = testcaselist.FirstOrDefault(o => o.DisplayName == "ThatWeExist(1)");
+            var testcase1 = testcaselist.FirstOrDefault(o => o.DisplayName == "ClassLibrary11.ManyTests.ThatWeExist(1)");
             Assert.That(testcase1, Is.Not.Null, "Didn't find the first testcase");
             Assert.That(testcase1.GetCategories().Count(), Is.EqualTo(3), "Wrong number of categories for first test case");
 
-            var testcase2 = testcaselist.FirstOrDefault(o => o.DisplayName == "ThatWeExist(2)");
+            var testcase2 = testcaselist.FirstOrDefault(o => o.DisplayName == "ClassLibrary11.ManyTests.ThatWeExist(2)");
             Assert.That(testcase2, Is.Not.Null, "Didn't find the second testcase");
             Assert.That(testcase2.GetCategories().Count(), Is.EqualTo(3), "Wrong number of categories for second test case");
 
@@ -419,7 +419,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             ProcessXml2TestCase(xml);
 
             Assert.That(testcaselist.Count, Is.EqualTo(3), "Wrong number of testcases found");
-            var testcase1 = testcaselist.FirstOrDefault(o => o.DisplayName == "dNunitTest");
+            var testcase1 = testcaselist.FirstOrDefault(o => o.DisplayName == "nUnitClassLibrary.ClassD.dNunitTest");
             Assert.That(testcase1, Is.Not.Null, "Didn't find the  testcase");
             VerifyCategoriesOnly(testcase1, 3, "derived");
        }
@@ -432,7 +432,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             ProcessXml2TestCase(xml);
 
             Assert.That(testcaselist.Count, Is.EqualTo(2), "Wrong number of testcases found");
-            var testcase1 = testcaselist.FirstOrDefault(o => o.DisplayName == "NC21");
+            var testcase1 = testcaselist.FirstOrDefault(o => o.DisplayName == "nUnitClassLibrary.NestedClasses+NestedClass2.NC21");
             Assert.That(testcase1, Is.Not.Null, "Didn't find the  testcase");
             VerifyCategoriesOnly(testcase1, 2, "nested");
         }
@@ -502,7 +502,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             ProcessXml2TestCase(xml);
 
             Assert.That(testcaselist.Count, Is.EqualTo(1), "Wrong number of testcases found");
-            var testcase1 = testcaselist.FirstOrDefault(o => o.DisplayName == "ThatWeExist");
+            var testcase1 = testcaselist.FirstOrDefault(o => o.DisplayName == "ClassLibrary11.StandardClass.ThatWeExist");
             Assert.That(testcase1, Is.Not.Null, "Didn't find the  testcase");
 
             VerifyCategoriesOnly(testcase1, 2, "first");
@@ -552,7 +552,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         {
             var testCase = GetTestCases(
                 @"<test-suite id='1' name='Fixture' fullname='Fixture' classname='Fixture'>
-                    <test-case id='2' name='Test' fullname='Fixture.Test' methodname='Test' classname='Fixture' runstate='Explicit' />
+                    <test-case id='2' name='Fixture.Test' fullname='Fixture.Test' methodname='Test' classname='Fixture' runstate='Explicit' />
                 </test-suite>").Single();
 
             Assert.That(testCase.Traits, Has.One.With.Property("Name").EqualTo("Explicit"));
@@ -563,7 +563,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         {
             var testCase = GetTestCases(
                 @"<test-suite id='1' name='Fixture' fullname='Fixture' classname='Fixture' runstate='Explicit'>
-                    <test-case id='2' name='Test' fullname='Fixture.Test' methodname='Test' classname='Fixture'/>
+                    <test-case id='2' name='Fixture.Test' fullname='Fixture.Test' methodname='Test' classname='Fixture'/>
                 </test-suite>").Single();
 
             Assert.That(testCase.Traits, Has.One.With.Property("Name").EqualTo("Explicit"));
@@ -574,8 +574,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         {
             var testCases = GetTestCases(
                 @"<test-suite id='1' name='Fixture' fullname='Fixture' classname='Fixture' runstate='Explicit'>
-                    <test-case id='2' name='Test' fullname='Fixture.Test' methodname='Test' classname='Fixture'/>
-                    <test-case id='3' name='Test2' fullname='Fixture.Test2' methodname='Test2' classname='Fixture'/>
+                    <test-case id='2' name='Fixture.Test' fullname='Fixture.Test' methodname='Test' classname='Fixture'/>
+                    <test-case id='3' name='Fixture.Test2' fullname='Fixture.Test2' methodname='Test2' classname='Fixture'/>
                 </test-suite>");
 
             foreach (var testCase in testCases)
@@ -587,7 +587,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         {
             var testCase = GetTestCases(
                 @"<test-suite id='1' name='Fixture' fullname='Fixture' classname='Fixture'>
-                    <test-case id='2' name='Test' fullname='Fixture.Test' methodname='Test' classname='Fixture' runstate='Explicit' />
+                    <test-case id='2' name='Fixture.Test' fullname='Fixture.Test' methodname='Test' classname='Fixture' runstate='Explicit' />
                 </test-suite>").Single();
 
             Assert.That(testCase.Traits, Has.One.With.Property("Name").EqualTo("Explicit").And.Property("Value").SameAs(string.Empty));


### PR DESCRIPTION
In order to avoid duplicates on "dotnet test -t" output, the parameter DisplayName should use the test's full namespace.
This way should be good to enable Visual Studio Code (and [Test Explorer Extension](https://github.com/formulahendry/vscode-dotnet-test-explorer)) to identify and match test cases like xUnit.