### PR TITLE
Proposed .NET Core SDK upgrade to allow running of all tests

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -177,8 +177,6 @@ foreach (var (framework, vstestFramework, adapterDir) in new[] {
             VSTest(GetTestAssemblyPath(framework), settings);
         });
 
-    const string NoNavigationTests = "TestCategory != Navigation";
-
     Task($"DotnetTest-{framework}")
         .IsDependentOn("Build")
         .Does(() =>
@@ -189,8 +187,7 @@ foreach (var (framework, vstestFramework, adapterDir) in new[] {
                 Framework = framework,
                 NoBuild = true,
                 TestAdapterPath = adapterDir,
-                Settings = File("DisableAppDomain.runsettings"),
-                Filter = framework == "net46" ? NoNavigationTests : null
+                Settings = File("DisableAppDomain.runsettings")
             });
         });
 
@@ -202,8 +199,7 @@ foreach (var (framework, vstestFramework, adapterDir) in new[] {
             {
                 TestAdapterPath = adapterDir,
                 Framework = vstestFramework,
-                Settings = File("DisableAppDomain.runsettings"),
-                TestCaseFilter = framework == "net46" ? NoNavigationTests : null
+                Settings = File("DisableAppDomain.runsettings")
             });
         });
 }

--- a/build.cake
+++ b/build.cake
@@ -183,18 +183,6 @@ foreach (var (framework, vstestFramework, adapterDir) in new[] {
                 Settings = File("DisableAppDomain.runsettings")
             });
         });
-
-    Task($"DotnetVSTest-{framework}")
-        .IsDependentOn("Build")
-        .Does(() =>
-        {
-            DotNetCoreVSTest(GetTestAssemblyPath(framework), new DotNetCoreVSTestSettings
-            {
-                TestAdapterPath = adapterDir,
-                Framework = vstestFramework,
-                Settings = File("DisableAppDomain.runsettings")
-            });
-        });
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -301,9 +289,7 @@ Task("Test")
     .IsDependentOn("VSTest-net46")
     .IsDependentOn("VSTest-netcoreapp1.0")
     .IsDependentOn("DotnetTest-net46")
-    .IsDependentOn("DotnetTest-netcoreapp1.0")
-    .IsDependentOn("DotnetVSTest-net46")
-    .IsDependentOn("DotnetVSTest-netcoreapp1.0");
+    .IsDependentOn("DotnetTest-netcoreapp1.0");
 
 Task("Package")
     .IsDependentOn("PackageZip")

--- a/build.cake
+++ b/build.cake
@@ -157,24 +157,17 @@ foreach (var (framework, vstestFramework, adapterDir) in new[] {
         .IsDependentOn("Build")
         .Does(() =>
         {
-            var settings = new VSTestSettings
+            VSTest(GetTestAssemblyPath(framework), new VSTestSettings
             {
                 TestAdapterPath = adapterDir,
                 // Enables the tests to run against the correct version of Microsoft.VisualStudio.TestPlatform.ObjectModel.dll.
                 // (The DLL they are compiled against depends on VS2012 at runtime.)
-                SettingsFile = File("DisableAppDomain.runsettings")
-            };
+                SettingsFile = File("DisableAppDomain.runsettings"),
 
-            // https://github.com/Microsoft/vswhere/issues/126#issuecomment-360542783
-            var vstestInstallation = VSWhereLatest(new VSWhereLatestSettings
-            {
-                Requires = "Microsoft.VisualStudio.TestTools.TestPlatform.V1.CLI"
-            }.WithRawArgument("-products *"));
-
-            if (vstestInstallation != null) settings.ToolPath = vstestInstallation
-                .CombineWithFilePath(@"Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe");
-
-            VSTest(GetTestAssemblyPath(framework), settings);
+                // https://github.com/cake-build/cake/issues/2077
+                #tool Microsoft.TestPlatform
+                ToolPath = Context.Tools.Resolve("vstest.console.exe")
+            });
         });
 
     Task($"DotnetTest-{framework}")

--- a/build.ps1
+++ b/build.ps1
@@ -32,8 +32,7 @@ Param(
 )
 
 $CakeVersion = "0.26.0"
-$DotNetChannel = "preview";
-$DotNetVersion = "1.1.4";
+$DotNetVersion = "2.1.201";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 
@@ -82,7 +81,7 @@ if($FoundDotNetCliVersion -ne $DotNetVersion) {
         mkdir -Force $InstallPath | Out-Null;
     }
     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
-    & $InstallPath\dotnet-install.ps1 -Channel $DotNetChannel -Version $DotNetVersion -InstallDir $InstallPath;
+    & $InstallPath\dotnet-install.ps1 -Version $DotNetVersion -InstallDir $InstallPath;
 
     Remove-PathVariable "$InstallPath"
     $env:PATH = "$InstallPath;$env:PATH"


### PR DESCRIPTION
The VSTest team made me aware that the registration-free COM error is fixed in the most recent releases of the .NET Core SDK. (https://github.com/Microsoft/vstest/issues/1432) This means we are no longer required to skip navigation data tests when using the `dotnet` CLI.

The first commit updates to SDK 2.1.201 and removes our workaround.

**Question 1:** is it okay to stop testing against .NET Core 1.0 (via SDK 1.1) and test against .NET Core 2.0 (via SDK 2.1)? If not, should we also be testing against .NET Core 1.1 and .NET Core 2.1-rc in addition to the other two officially-supported versions? (https://www.microsoft.com/net/Support/Policy)

<br>

The second commit is because I happened to notice that the version of VSTest run by `dotnet test` (bundled in .NET Core SDK 2.1.201) is 15.7.0-preview-20180221-13, and I remembered VSTest.Console.exe is now designed to be consumed via NuGet so that we no longer need to be dependent on the version of VS which is installed on the user machine (🎉).

**Question 2:** Is there any reason to keep testing against the VSTest installation deployed by the Visual Studio installer instead of the NuGet package?

<br>

The final commit is because the `DotnetVSTest-` tasks are running test runs which are identical to our `DotnetTest-` tasks. All we had been truly testing was that the dotnet CLI is working the way it is documented to work.
Also, the `DotnetVSTest-` test runs are now identical to the `VSTest-` test runs except that the  `VSTest-` tasks now use a newer release version of VSTest.

**Question 3:** What if we dropped our `VSTest-` tasks and just used the `DotnetTest-` tasks? We can do that now that we don't have the COM error and now that the VSTest team seems to be shipping the product the exact same way to NuGet, Visual Studio, and bundled within the .NET Core SDK.






