### PR TITLE
Productize NUnit.Explicit

### DIFF
--- a/src/NUnitTestAdapterTests/Filtering/FilteringTestUtils.cs
+++ b/src/NUnitTestAdapterTests/Filtering/FilteringTestUtils.cs
@@ -29,7 +29,6 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using NSubstitute;
 using NUnit.Framework;
-using NUnit.VisualStudio.TestAdapter.Tests.Fakes;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
 {
@@ -62,17 +61,6 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
             var matchingTestCases = CreateTestFilter(filterExpression).CheckFilter(testCases);
 
             Assert.That(matchingTestCases.Select(t => t.FullyQualifiedName), Is.EquivalentTo(expectedMatchingTestNames));
-        }
-
-        public static IReadOnlyCollection<TestCase> ConvertTestCases(string xml)
-        {
-            using (var testConverter = new TestConverter(
-                new TestLogger(new MessageLoggerStub()),
-                FakeTestData.AssemblyPath,
-                collectSourceInformation: false))
-            {
-                return testConverter.ConvertTestCases(xml);
-            }
         }
     }
 }

--- a/src/NUnitTestAdapterTests/Filtering/TestFilterTests.cs
+++ b/src/NUnitTestAdapterTests/Filtering/TestFilterTests.cs
@@ -162,7 +162,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
         {
             FilteringTestUtils.AssertExpectedResult(
                 TestDoubleFilterExpression.AnyIsEqualTo("TestCategory", category),
-                FilteringTestUtils.ConvertTestCases(FakeTestData.HierarchyTestXml),
+                TestCaseUtils.ConvertTestCases(FakeTestData.HierarchyTestXml),
                 expectedMatchingTestNames);
         }
 
@@ -180,7 +180,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
         {
             FilteringTestUtils.AssertExpectedResult(
                 TestDoubleFilterExpression.AnyIsEqualTo("Category", category),
-                FilteringTestUtils.ConvertTestCases(FakeTestData.HierarchyTestXml),
+                TestCaseUtils.ConvertTestCases(FakeTestData.HierarchyTestXml),
                 expectedMatchingTestNames);
         }
     }

--- a/src/NUnitTestAdapterTests/Filtering/VSTestFilterStringTests.cs
+++ b/src/NUnitTestAdapterTests/Filtering/VSTestFilterStringTests.cs
@@ -68,7 +68,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Filtering
             var filter = FilteringTestUtils.CreateTestFilter(string.IsNullOrEmpty(vsTestFilterString) ? null :
                 FilteringTestUtils.CreateVSTestFilterExpression(vsTestFilterString));
 
-            return filter.CheckFilter(FilteringTestUtils.ConvertTestCases(testCasesXml));
+            return filter.CheckFilter(TestCaseUtils.ConvertTestCases(testCasesXml));
         }
     }
 }

--- a/src/NUnitTestAdapterTests/TestCaseUtils.cs
+++ b/src/NUnitTestAdapterTests/TestCaseUtils.cs
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using NUnit.VisualStudio.TestAdapter.Tests.Fakes;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
 {
@@ -50,6 +51,17 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 testCases[i] = testConverter.ConvertTestCase(testCaseNodes[i]);
 
             return testCases;
+        }
+
+        public static IReadOnlyCollection<TestCase> ConvertTestCases(string xml)
+        {
+            using (var testConverter = new TestConverter(
+                new TestLogger(new MessageLoggerStub()),
+                FakeTestData.AssemblyPath,
+                collectSourceInformation: false))
+            {
+                return testConverter.ConvertTestCases(xml);
+            }
         }
     }
 }

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -191,6 +191,42 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             }
         }
 
+        [Description("Third-party runners may opt to depend on this. https://github.com/nunit/nunit3-vs-adapter/issues/487#issuecomment-389222879")]
+        [TestCase("NonExplicitParent.ExplicitTest")]
+        [TestCase("ExplicitParent.NonExplicitTest")]
+        public static void NUnitExplicitBoolPropertyIsProvidedForThirdPartyRunnersInExplicitTestCases(string testName)
+        {
+            var testCase = GetSampleTestCase(testName);
 
+            var property = testCase.Properties.Single(p =>
+                p.Id == "NUnit.Explicit"
+                && p.GetValueType() == typeof(bool));
+
+            Assert.That(testCase.GetPropertyValue(property), Is.True);
+        }
+
+        [TestCase("NonExplicitParent.NonExplicitTestWithExplicitCategory")]
+        public static void NUnitExplicitBoolPropertyIsNotProvidedForThirdPartyRunnersInNonExplicitTestCases(string testName)
+        {
+            var testCase = GetSampleTestCase(testName);
+
+            Assert.That(testCase, Has.Property("Properties").With.None.With.Property("Id").EqualTo("NUnit.Explicit"));
+        }
+
+        private static TestCase GetSampleTestCase(string fullyQualifiedName)
+        {
+            return TestCaseUtils.ConvertTestCases(@"
+                <test-suite id='1' name='NonExplicitParent' fullname='NonExplicitParent'>
+                    <test-case id='2' name='NonExplicitTest' fullname='NonExplicitParent.NonExplicitTestWithExplicitCategory'>
+                        <properties>
+                            <property name='Category' value='Explicit' />
+                        </properties>
+                    </test-case>
+                    <test-case id='3' name='ExplicitTest' fullname='NonExplicitParent.ExplicitTest' runstate='Explicit' />
+                </test-suite>
+                <test-suite id='4' name='ExplicitParent' fullname='ExplicitParent' runstate='Explicit'>
+                    <test-case id='5' name='NonExplicitTest' fullname='ExplicitParent.NonExplicitTest' />
+                </test-suite>").Single(t => t.FullyQualifiedName == fullyQualifiedName);
+        }
     }
 }


### PR DESCRIPTION
If I understand correctly, @estrizhok indicated that it would be useful to be able to rely on the continued presence of the NUnit.Explicit property so that the Rider UI could natively respect the concept of explicit test selection.
@OsirisTerje, it looks like you were in favor of this approach. If we encourage this route, can we add these tests to ensure that we don't accidentally change the property name, type or behavior, and forget that it might affect external runners?

Should we hold off on merging this until https://github.com/nunit/nunit3-vs-adapter/issues/487 is settled?

