### PR TITLE
Add a CollectDataForEachTestSeparately setting

### DIFF
--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -248,9 +248,14 @@ namespace NUnit.VisualStudio.TestAdapter
             var inProcDataCollectorNode = doc.SelectSingleNode("RunSettings/InProcDataCollectionRunSettings/InProcDataCollectors");
             InProcDataCollectorsAvailable = inProcDataCollectorNode != null && inProcDataCollectorNode.SelectNodes("InProcDataCollector").Count > 0;
 
+            // Older versions of VS do not pass the CollectDataForEachTestSeparately configuration together with the LiveUnitTesting collector.
+            // However, the adapter is expected to run in CollectDataForEachTestSeparately mode.
+            // As a result for backwards compatibility reasons enable CollectDataForEachTestSeparately mode whenever LiveUnitTesting collector is being used.
+            var hasLiveUnitTestingDataCollector = inProcDataCollectorNode?.SelectSingleNode("InProcDataCollector[@uri='InProcDataCollector://Microsoft/LiveUnitTesting/1.0']") != null;
+
             // TestPlatform can opt-in to run tests one at a time so that the InProcDataCollectors can collect the data for each one of them separately.
             // In that case, we need to ensure that tests do not run in parallel and the test started/test ended events are sent synchronously.
-            if (CollectDataForEachTestSeparately)
+            if (CollectDataForEachTestSeparately || hasLiveUnitTestingDataCollector)
             {
                 NumberOfTestWorkers = 0;
                 SynchronousEvents = true;

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -280,5 +280,23 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(_settings.NumberOfTestWorkers, Is.EqualTo(-1));
             Assert.True(_settings.InProcDataCollectorsAvailable);
         }
+
+        [Test]
+        public void LiveUnitTestingDataCollector()
+        {
+            _settings.Load(@"
+<RunSettings>
+    <InProcDataCollectionRunSettings>
+        <InProcDataCollectors>
+            <InProcDataCollector friendlyName='DummyCollectorName' uri='InProcDataCollector://Microsoft/LiveUnitTesting/1.0' />
+        </InProcDataCollectors>
+    </InProcDataCollectionRunSettings>
+</RunSettings>");
+
+            Assert.Null(_settings.DomainUsage);
+            Assert.True(_settings.SynchronousEvents);
+            Assert.That(_settings.NumberOfTestWorkers, Is.Zero);
+            Assert.True(_settings.InProcDataCollectorsAvailable);
+        }
     }
 }

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -243,6 +243,27 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         }
 
         [Test]
+        public void CollectDataForEachTestSeparately()
+        {
+            _settings.Load(@"
+<RunSettings>
+    <RunConfiguration>
+        <CollectDataForEachTestSeparately>true</CollectDataForEachTestSeparately>
+    </RunConfiguration>
+    <InProcDataCollectionRunSettings>
+        <InProcDataCollectors>
+            <InProcDataCollector friendlyName='DummyCollectorName' uri='InProcDataCollector://NUnit/DummyCollectorName' />
+        </InProcDataCollectors>
+    </InProcDataCollectionRunSettings>
+</RunSettings>");
+
+            Assert.Null(_settings.DomainUsage);
+            Assert.True(_settings.SynchronousEvents);
+            Assert.That(_settings.NumberOfTestWorkers, Is.Zero);
+            Assert.True(_settings.InProcDataCollectorsAvailable);
+        }
+
+        [Test]
         public void InProcDataCollector()
         {
             _settings.Load(@"
@@ -254,9 +275,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
     </InProcDataCollectionRunSettings>
 </RunSettings>");
 
-            Assert.That(_settings.DomainUsage, Is.EqualTo("None"));
-            Assert.True(_settings.SynchronousEvents);
-            Assert.That(_settings.NumberOfTestWorkers, Is.Zero);
+            Assert.Null(_settings.DomainUsage);
+            Assert.False(_settings.SynchronousEvents);
+            Assert.That(_settings.NumberOfTestWorkers, Is.EqualTo(-1));
             Assert.True(_settings.InProcDataCollectorsAvailable);
         }
     }


### PR DESCRIPTION
Add a setting to make NUnit run tests sequentially, making the InProcDataCollectors receive the events before a test starts and after a test ends. This allows adapters to opt into the sequential mode.

It adds a fallback for the old LiveUnitTesting adapter, so that when present the tests are running in a sequential mode, so that the new NUnit adapter keeps working with older releases of VS.

Fixes #426