### PR TITLE
 TestConverter: added check for attachment path - if it starts with file:// scheme

### DIFF
--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -240,12 +240,18 @@ namespace NUnit.VisualStudio.TestAdapter
         /// <returns>attachments to be added to the test, it will be empty if no attachments are found</returns>
         private AttachmentSet ParseAttachments(XmlNode resultNode)
         {
+            const string fileUriScheme = "file://";
             var attachmentSet = new AttachmentSet(new Uri(NUnitTestAdapter.ExecutorUri), "Attachments");
 
             foreach (XmlNode attachment in resultNode.SelectNodes("attachments/attachment"))
             {
                 var path = attachment.SelectSingleNode("filePath")?.InnerText ?? string.Empty;
                 var description = attachment.SelectSingleNode("description")?.InnerText;
+
+                if ( !(string.IsNullOrEmpty(path) || path.StartsWith(fileUriScheme, StringComparison.OrdinalIgnoreCase)))
+                {
+                    path = fileUriScheme + path;
+                }
 
                 try
                 {

--- a/src/NUnitTestAdapterTests/Fakes/FakeTestData.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeTestData.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -46,7 +46,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
                     <property name='Category' value='super' />
                 </properties>
                 <test-case
-                    id='123' 
+                    id='123'
                     name='FakeTestCase'
                     fullname='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData.FakeTestCase'
                     methodname='FakeTestCase'
@@ -59,61 +59,61 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
             </test-suite>";
 
         public const string HierarchyTestXml = @"<test-run id='2' name='nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' testcasecount='5'>
-	<test-suite type='Assembly' id='0-1009' name='nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' runstate='Runnable' testcasecount='5'>
-		<properties>
-			<property name='Category' value='AsmCat' />
-			<property name='_PID' value='6164' />
-			<property name='_APPDOMAIN' value='domain-71b2ab93-nUnitClassLibrary.dll' />
-		</properties>
-		<test-suite type='TestSuite' id='0-1010' name='nUnitClassLibrary' fullname='nUnitClassLibrary' runstate='Runnable' testcasecount='5'>
-			<test-suite type='TestFixture' id='0-1000' name='Class1' fullname='nUnitClassLibrary.Class1' classname='nUnitClassLibrary.Class1' runstate='Runnable' testcasecount='1'>
-				<properties>
-					<property name='Category' value='BaseClass' />
-				</properties>
-				<test-case id='0-1001' name='nUnitTest' fullname='nUnitClassLibrary.Class1.nUnitTest' methodname='nUnitTest' classname='nUnitClassLibrary.Class1' runstate='Runnable' seed='113395783'>
-					<properties>
-						<property name='Category' value='Base' />
-					</properties>
-				</test-case>
-			</test-suite>
-			<test-suite type='TestFixture' id='0-1002' name='ClassD' fullname='nUnitClassLibrary.ClassD' classname='nUnitClassLibrary.ClassD' runstate='Runnable' testcasecount='2'>
-				<properties>
-					<property name='Category' value='DerivedClass' />
-					<property name='Category' value='BaseClass' />
-				</properties>
-				<test-case id='0-1003' name='dNunitTest' fullname='nUnitClassLibrary.ClassD.dNunitTest' methodname='dNunitTest' classname='nUnitClassLibrary.ClassD' runstate='Runnable' seed='405714082'>
-					<properties>
-						<property name='Category' value='Derived' />
-					</properties>
-				</test-case>
-				<test-case id='0-1004' name='nUnitTest' fullname='nUnitClassLibrary.ClassD.nUnitTest' methodname='nUnitTest' classname='nUnitClassLibrary.Class1' runstate='Runnable' seed='1553985978'>
-					<properties>
-						<property name='Category' value='Base' />
-					</properties>
-				</test-case>
-			</test-suite>
-			<test-suite type='TestFixture' id='0-1005' name='NestedClasses' fullname='nUnitClassLibrary.NestedClasses' classname='nUnitClassLibrary.NestedClasses' runstate='Runnable' testcasecount='1'>
-				<properties>
-					<property name='Category' value='NS1' />
-				</properties>
-				<test-case id='0-1006' name='NC11' fullname='nUnitClassLibrary.NestedClasses.NC11' methodname='NC11' classname='nUnitClassLibrary.NestedClasses' runstate='Runnable' seed='1107340752'>
-					<properties>
-						<property name='Category' value='NS11' />
-					</properties>
-				</test-case>
-			</test-suite>
-			<test-suite type='TestFixture' id='0-1007' name='NestedClasses+NestedClass2' fullname='nUnitClassLibrary.NestedClasses+NestedClass2' classname='nUnitClassLibrary.NestedClasses+NestedClass2' runstate='Runnable' testcasecount='1'>
-				<properties>
-					<property name='Category' value='NS2' />
-				</properties>
-				<test-case id='0-1008' name='NC21' fullname='nUnitClassLibrary.NestedClasses+NestedClass2.NC21' methodname='NC21' classname='nUnitClassLibrary.NestedClasses+NestedClass2' runstate='Runnable' seed='1823789309'>
-					<properties>
-						<property name='Category' value='NS21' />
-					</properties>
-				</test-case>
-			</test-suite>
-		</test-suite>
-	</test-suite>
+    <test-suite type='Assembly' id='0-1009' name='nUnitClassLibrary.dll' fullname='C:\Users\navb\source\repos\nUnitClassLibrary\nUnitClassLibrary\bin\Debug\nUnitClassLibrary.dll' runstate='Runnable' testcasecount='5'>
+        <properties>
+            <property name='Category' value='AsmCat' />
+            <property name='_PID' value='6164' />
+            <property name='_APPDOMAIN' value='domain-71b2ab93-nUnitClassLibrary.dll' />
+        </properties>
+        <test-suite type='TestSuite' id='0-1010' name='nUnitClassLibrary' fullname='nUnitClassLibrary' runstate='Runnable' testcasecount='5'>
+            <test-suite type='TestFixture' id='0-1000' name='Class1' fullname='nUnitClassLibrary.Class1' classname='nUnitClassLibrary.Class1' runstate='Runnable' testcasecount='1'>
+                <properties>
+                    <property name='Category' value='BaseClass' />
+                </properties>
+                <test-case id='0-1001' name='nUnitTest' fullname='nUnitClassLibrary.Class1.nUnitTest' methodname='nUnitTest' classname='nUnitClassLibrary.Class1' runstate='Runnable' seed='113395783'>
+                    <properties>
+                        <property name='Category' value='Base' />
+                    </properties>
+                </test-case>
+            </test-suite>
+            <test-suite type='TestFixture' id='0-1002' name='ClassD' fullname='nUnitClassLibrary.ClassD' classname='nUnitClassLibrary.ClassD' runstate='Runnable' testcasecount='2'>
+                <properties>
+                    <property name='Category' value='DerivedClass' />
+                    <property name='Category' value='BaseClass' />
+                </properties>
+                <test-case id='0-1003' name='dNunitTest' fullname='nUnitClassLibrary.ClassD.dNunitTest' methodname='dNunitTest' classname='nUnitClassLibrary.ClassD' runstate='Runnable' seed='405714082'>
+                    <properties>
+                        <property name='Category' value='Derived' />
+                    </properties>
+                </test-case>
+                <test-case id='0-1004' name='nUnitTest' fullname='nUnitClassLibrary.ClassD.nUnitTest' methodname='nUnitTest' classname='nUnitClassLibrary.Class1' runstate='Runnable' seed='1553985978'>
+                    <properties>
+                        <property name='Category' value='Base' />
+                    </properties>
+                </test-case>
+            </test-suite>
+            <test-suite type='TestFixture' id='0-1005' name='NestedClasses' fullname='nUnitClassLibrary.NestedClasses' classname='nUnitClassLibrary.NestedClasses' runstate='Runnable' testcasecount='1'>
+                <properties>
+                    <property name='Category' value='NS1' />
+                </properties>
+                <test-case id='0-1006' name='NC11' fullname='nUnitClassLibrary.NestedClasses.NC11' methodname='NC11' classname='nUnitClassLibrary.NestedClasses' runstate='Runnable' seed='1107340752'>
+                    <properties>
+                        <property name='Category' value='NS11' />
+                    </properties>
+                </test-case>
+            </test-suite>
+            <test-suite type='TestFixture' id='0-1007' name='NestedClasses+NestedClass2' fullname='nUnitClassLibrary.NestedClasses+NestedClass2' classname='nUnitClassLibrary.NestedClasses+NestedClass2' runstate='Runnable' testcasecount='1'>
+                <properties>
+                    <property name='Category' value='NS2' />
+                </properties>
+                <test-case id='0-1008' name='NC21' fullname='nUnitClassLibrary.NestedClasses+NestedClass2.NC21' methodname='NC21' classname='nUnitClassLibrary.NestedClasses+NestedClass2' runstate='Runnable' seed='1823789309'>
+                    <properties>
+                        <property name='Category' value='NS21' />
+                    </properties>
+                </test-case>
+            </test-suite>
+        </test-suite>
+    </test-suite>
 </test-run>";
         #endregion
 
@@ -127,7 +127,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
                     <property name='Category' value='super' />
                 </properties>
                 <test-case
-                    id='123' 
+                    id='123'
                     name='FakeTestCase'
                     fullname='NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData.FakeTestCase'
                     methodname='FakeTestCase'
@@ -143,6 +143,28 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
                     <reason>
                         <message>It passed!</message>
                     </reason>
+                    <attachments>
+                        <attachment>
+                            <filePath>c:\results\att.log</filePath>
+                            <description>win, no scheme</description>
+                        </attachment>
+                        <attachment>
+                            <filePath>file://c:\results\att.log</filePath>
+                            <description>win, with scheme</description>
+                        </attachment>
+                        <attachment>
+                            <filePath>/home/results/att.log</filePath>
+                            <description>lin, no scheme</description>
+                        </attachment>
+                        <attachment>
+                            <filePath>file:///home/results/att.log</filePath>
+                            <description>lin, with scheme</description>
+                        </attachment>
+                        <attachment>
+                            <filePath></filePath>
+                            <description>empty path</description>
+                        </attachment>
+                    </attachments>
                 </test-case>
             </test-suite>";
 
@@ -150,12 +172,12 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
 
         public const string FullyQualifiedName = "NUnit.VisualStudio.TestAdapter.Tests.Fakes.FakeTestData.FakeTestCase";
 
-        public static readonly string AssemblyPath = 
+        public static readonly string AssemblyPath =
             typeof(FakeTestData).GetTypeInfo().Assembly.ManifestModule.FullyQualifiedName;
 
         public static readonly string CodeFile = Path.Combine(Path.GetDirectoryName(AssemblyPath), @"..\..\..\Fakes\FakeTestData.cs");
 
-        // NOTE: If the location of the FakeTestCase method defined 
+        // NOTE: If the location of the FakeTestCase method defined
         // above changes, update the value of LineNumber.
         public const int LineNumber = 36;
 


### PR DESCRIPTION
The PR fixes the problem from [issue 494](https://github.com/nunit/nunit3-vs-adapter/issues/494).

I added constant **fileUriScheme** into helper method ```AttachmentSet ParseAttachments(XmlNode resultNode)```.
Then I added check for each path in attachments. 
When path is not empty or not already started with **fileUriScheme**, **fileUriScheme** value is added at the beginning of the original path.