### PR TITLE
 Embed Mono.Cecil so user dependencies are no longer overwritten 

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="AppVeyor NUnit CI Feed" value="https://ci.appveyor.com/nuget/nunit" />
-        <add key="AppVeyor NUnit Engine CI Feed" value="https://ci.appveyor.com/nuget/nunit-console" />
-        <add key="NUnit MyGet Feed" value="https://www.myget.org/F/nunit/api/v2" />
-        <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    </packageSources>
-</configuration>

--- a/acceptance.cake
+++ b/acceptance.cake
@@ -16,6 +16,7 @@ Task("Acceptance")
         {
             BuildAndVerifySinglePassingTest("Simple", "net35", "netcoreapp1.0");
             BuildAndVerifySinglePassingTest("Referencing Mono.Cecil", "net35", "netcoreapp1.0");
+            BuildAndVerifySinglePassingTest("Referencing Mono.Cecil 0.10.0", "net35", "netcoreapp1.0");
 
             void BuildAndVerifySinglePassingTest(string projectName, params string[] targetFrameworks)
             {

--- a/acceptance.cake
+++ b/acceptance.cake
@@ -14,10 +14,19 @@ Task("Acceptance")
 
         using (var tempDirectory = new TempDirectory())
         {
-            var simple = NewProjectFixture(@"tests\Simple", acceptanceTestConfiguration, tempDirectory);
-            simple.Build(packageVersion);
-            VerifySinglePassingTest(simple.Test("net35"));
-            VerifySinglePassingTest(simple.Test("netcoreapp1.0"));
+            BuildAndVerifySinglePassingTest("Simple", "net35", "netcoreapp1.0");
+            BuildAndVerifySinglePassingTest("Referencing Mono.Cecil", "net35", "netcoreapp1.0");
+
+            void BuildAndVerifySinglePassingTest(string projectName, params string[] targetFrameworks)
+            {
+                var project = NewProjectFixture(Directory($@"tests\{projectName}"), acceptanceTestConfiguration, tempDirectory);
+                project.Build(packageVersion);
+
+                foreach (var targetFramework in targetFrameworks)
+                {
+                    VerifySinglePassingTest(project.Test(targetFramework));
+                }
+            }
         }
     });
 

--- a/acceptance.cake
+++ b/acceptance.cake
@@ -1,0 +1,36 @@
+#load lib.cake
+
+using System.Xml.Linq;
+
+const string acceptanceTestConfiguration = "Release";
+
+Task("Acceptance")
+    .IsDependentOn("Build")
+    .IsDependentOn("PackageNuGet")
+    .Description("Ensures that known project configurations can use the produced NuGet package to restore, build, and run tests.")
+    .Does(() =>
+    {
+        DeleteDirectoryRobust(@"tests\Isolated package cache\nunit3testadapter");
+
+        using (var tempDirectory = new TempDirectory())
+        {
+            var simple = NewProjectFixture(@"tests\Simple", acceptanceTestConfiguration, tempDirectory);
+            simple.Build(packageVersion);
+            VerifySinglePassingTest(simple.Test("net35"));
+            VerifySinglePassingTest(simple.Test("netcoreapp1.0"));
+        }
+    });
+
+void VerifySinglePassingTest(FilePath trxPath)
+{
+    var ns = (XNamespace)"http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+
+    var counters = XElement.Load(trxPath.FullPath)
+        .Element(ns + "ResultSummary")
+        .Element(ns + "Counters");
+
+    if (counters.Attribute("total").Value != "1" || counters.Attribute("passed").Value != "1")
+    {
+        throw new Exception("Expected a single passing test result.");
+    }
+}

--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,5 @@
+#load lib.cake
+#load acceptance.cake
 #tool nuget:?package=vswhere
 
 //////////////////////////////////////////////////////////////////////
@@ -258,26 +260,6 @@ Task("PackageVsix")
     });
 
 //////////////////////////////////////////////////////////////////////
-// HELPER METHODS
-//////////////////////////////////////////////////////////////////////
-
-public static T WithRawArgument<T>(this T settings, string rawArgument) where T : Cake.Core.Tooling.ToolSettings
-{
-    if (settings == null) throw new ArgumentNullException(nameof(settings));
-
-    if (!string.IsNullOrEmpty(rawArgument))
-    {
-        var previousCustomizer = settings.ArgumentCustomization;
-        if (previousCustomizer != null)
-            settings.ArgumentCustomization = builder => previousCustomizer.Invoke(builder).Append(rawArgument);
-        else
-            settings.ArgumentCustomization = builder => builder.Append(rawArgument);
-    }
-
-    return settings;
-}
-
-//////////////////////////////////////////////////////////////////////
 // TASK TARGETS
 //////////////////////////////////////////////////////////////////////
 
@@ -299,7 +281,8 @@ Task("Package")
 Task("Appveyor")
     .IsDependentOn("Build")
     .IsDependentOn("Test")
-    .IsDependentOn("Package");
+    .IsDependentOn("Package")
+    .IsDependentOn("Acceptance");
 
 Task("Default")
     .IsDependentOn("Build");

--- a/build.cake
+++ b/build.cake
@@ -212,8 +212,7 @@ Task("CreateWorkingImage")
             ADAPTER_BIN_DIR_NET35 + "NUnit3.TestAdapter.dll",
             ADAPTER_BIN_DIR_NET35 + "NUnit3.TestAdapter.pdb",
             ADAPTER_BIN_DIR_NET35 + "nunit.engine.dll",
-            ADAPTER_BIN_DIR_NET35 + "nunit.engine.api.dll",
-            ADAPTER_BIN_DIR_NET35 + "Mono.Cecil.dll"
+            ADAPTER_BIN_DIR_NET35 + "nunit.engine.api.dll"
         };
 
         var net35Dir = PACKAGE_IMAGE_DIR + "build/net35";

--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ Param(
     [string[]]$ScriptArgs
 )
 
-$CakeVersion = "0.26.0"
+$CakeVersion = "0.30.0"
 $DotNetVersion = "2.1.201";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"

--- a/lib.cake
+++ b/lib.cake
@@ -125,7 +125,8 @@ private sealed class ProjectFixture
             Framework = targetFramework,
             NoBuild = true,
             Logger = "trx;LogFileName=" + resultsFile.GetFilename(),
-            ResultsDirectory = resultsFile.GetDirectory()
+            ResultsDirectory = resultsFile.GetDirectory(),
+            Settings = _context.File("DisableAppDomain.runsettings")
         });
 
         return resultsFile;

--- a/lib.cake
+++ b/lib.cake
@@ -1,0 +1,133 @@
+public static T WithRawArgument<T>(this T settings, string rawArgument) where T : Cake.Core.Tooling.ToolSettings
+{
+    if (settings == null) throw new ArgumentNullException(nameof(settings));
+
+    if (!string.IsNullOrEmpty(rawArgument))
+    {
+        var previousCustomizer = settings.ArgumentCustomization;
+        if (previousCustomizer != null)
+            settings.ArgumentCustomization = builder => previousCustomizer.Invoke(builder).Append(rawArgument);
+        else
+            settings.ArgumentCustomization = builder => builder.Append(rawArgument);
+    }
+
+    return settings;
+}
+
+void DeleteDirectoryRobust(params string[] directories)
+{
+    DeleteDirectoryRobust(Context, directories);
+}
+
+static void DeleteDirectoryRobust(this ICakeContext context, params DirectoryPath[] directories)
+{
+    DeleteDirectoryRobust(context, Array.ConvertAll(directories, d => d.FullPath));
+}
+
+static void DeleteDirectoryRobust(this ICakeContext context, params string[] directories)
+{
+    if (!directories.Any()) return;
+
+    context.Information("Deleting directories:");
+
+    foreach (var directory in directories)
+    {
+        for (var attempt = 1;; attempt++)
+        {
+            context.Information(directory);
+            try
+            {
+                System.IO.Directory.Delete(directory, recursive: true);
+                break;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                break;
+            }
+            catch (IOException ex) when (attempt < 3 && (WinErrorCode)ex.HResult == WinErrorCode.DirNotEmpty)
+            {
+                context.Information("Another process added files to the directory while its contents were being deleted. Retrying...");
+            }
+        }
+    }
+}
+
+private enum WinErrorCode : ushort
+{
+    DirNotEmpty = 145
+}
+
+public sealed class TempDirectory : IDisposable
+{
+    public DirectoryPath Path { get; }
+
+    public TempDirectory()
+    {
+        Path = new DirectoryPath(System.IO.Path.GetTempPath()).Combine(System.IO.Path.GetRandomFileName());
+        System.IO.Directory.CreateDirectory(Path.FullPath);
+    }
+
+    public void Dispose()
+    {
+        System.IO.Directory.Delete(Path.FullPath, recursive: true);
+    }
+
+    public static implicit operator DirectoryPath(TempDirectory tempDirectory)
+    {
+        return tempDirectory.Path;
+    }
+}
+
+ProjectFixture NewProjectFixture(DirectoryPath projectDirectory, string configuration, DirectoryPath testResultsDirectory)
+{
+    return new ProjectFixture(Context, projectDirectory, configuration, testResultsDirectory);
+}
+
+private sealed class ProjectFixture
+{
+    private readonly ICakeContext _context;
+    private readonly DirectoryPath _projectDirectory;
+    private readonly string _configuration;
+    private readonly DirectoryPath _testResultsDirectory;
+
+    private string ProjectName => _projectDirectory.GetDirectoryName();
+
+    public ProjectFixture(ICakeContext context, DirectoryPath projectDirectory, string configuration, DirectoryPath testResultsDirectory)
+    {
+        _context = context;
+        _projectDirectory = projectDirectory;
+        _configuration = configuration;
+        _testResultsDirectory = testResultsDirectory;
+    }
+
+    public void Build(string adapterPackageVersion)
+    {
+        _context.DeleteDirectoryRobust(_projectDirectory.Combine("bin"));
+
+        var projectFile = _projectDirectory.CombineWithFilePath(ProjectName + ".csproj");
+        _context.XmlPoke(projectFile, "/Project/ItemGroup/PackageReference[@Include = 'NUnit3TestAdapter']/@Version", adapterPackageVersion);
+
+        _context.MSBuild(_projectDirectory.FullPath, new MSBuildSettings
+        {
+            WorkingDirectory = _projectDirectory,
+            Verbosity = Verbosity.Minimal,
+            Configuration = _configuration,
+        }.WithRestore());
+    }
+
+    public FilePath Test(string targetFramework)
+    {
+        var resultsFile = _testResultsDirectory.CombineWithFilePath($"{ProjectName}-{targetFramework}.trx");
+
+        _context.DotNetCoreTest(_projectDirectory.FullPath, new DotNetCoreTestSettings
+        {
+            Configuration = _configuration,
+            Framework = targetFramework,
+            NoBuild = true,
+            Logger = "trx;LogFileName=" + resultsFile.GetFilename(),
+            ResultsDirectory = resultsFile.GetDirectory()
+        });
+
+        return resultsFile;
+    }
+}

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -42,12 +42,10 @@ The package works with Visual Studio 2012 and newer.</description>
         <file src="build\net35\NUnit3.TestAdapter.pdb" target="build\net35\NUnit3.TestAdapter.pdb" />
         <file src="build\net35\nunit.engine.dll" target="build\net35\nunit.engine.dll" />
         <file src="build\net35\nunit.engine.api.dll" target="build\net35\nunit.engine.api.dll" />
-        <file src="build\net35\Mono.Cecil.dll" target="build\net35\Mono.Cecil.dll" />
         <file src="build\net35\NUnit3TestAdapter.props" target="build\net35\NUnit3TestAdapter.props" />
 
         <file src="build\netcoreapp1.0\NUnit3.TestAdapter.dll" target="build\netcoreapp1.0\NUnit3.TestAdapter.dll" />
         <file src="build\netcoreapp1.0\NUnit3.TestAdapter.pdb" target="build\netcoreapp1.0\NUnit3.TestAdapter.pdb" />
-        <file src="build\netcoreapp1.0\Mono.Cecil.dll" target="build\netcoreapp1.0\Mono.Cecil.dll" />
         <file src="build\netcoreapp1.0\nunit.engine.netstandard.dll" target="build\netcoreapp1.0\nunit.engine.netstandard.dll" />
         <file src="build\netcoreapp1.0\NUnit3TestAdapter.props" target="build\netcoreapp1.0\NUnit3TestAdapter.props" />
 

--- a/nuget/net35/NUnit3TestAdapter.props
+++ b/nuget/net35/NUnit3TestAdapter.props
@@ -21,10 +21,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)Mono.Cecil.dll">
-      <Link>Mono.Cecil.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </Content>
   </ItemGroup>
 </Project>

--- a/nuget/netcoreapp1.0/NUnit3TestAdapter.props
+++ b/nuget/netcoreapp1.0/NUnit3TestAdapter.props
@@ -16,10 +16,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)Mono.Cecil.dll">
-      <Link>Mono.Cecil.dll</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>False</Visible>
-    </Content>
   </ItemGroup>
 </Project>

--- a/src/Common.props
+++ b/src/Common.props
@@ -6,4 +6,18 @@
     <AssemblyOriginatorKeyFile>..\NUnitAdapter.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <Target Name="RemoveReferencesToEmbeddedAssembles" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <!-- Don’t copy Mono.Cecil to the output directory. Useful for debugging the embedded loading mechanism. -->
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(Filename)' == 'Mono.Cecil'" />
+
+      <!-- Important: remove references to Mono.Cecil at compile time. This is insurance.
+           If the compiled assembly has a reference to Mono.Cecil, the VSTest could try to load Mono.Cecil
+           while reflecting over the adapter types looking for interface implementations. Since VSTest would
+           be triggering the load of Mono.Cecil before we have a chance to handle AssemblyResolve, the load
+           would fail. VSTest does ignore the adapter assembly in this scenario. -->
+      <ReferencePath Remove="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)' == 'Mono.Cecil'" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/NUnit3TestAdapterInstall/NUnit3TestAdapterInstall.csproj
+++ b/src/NUnit3TestAdapterInstall/NUnit3TestAdapterInstall.csproj
@@ -1,4 +1,5 @@
 ﻿<Project ToolsVersion="15.0">
+  <Import Project="..\Common.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -25,7 +26,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
-    <VsixSourceItem Include="$(VsixInputFileLocation)\Mono.Cecil.dll" />
     <VsixSourceItem Include="$(VsixInputFileLocation)\nunit.engine.api.dll" />
     <VsixSourceItem Include="$(VsixInputFileLocation)\nunit.engine.dll" />
     <VsixSourceItem Include="$(VsixInputFileLocation)\NUnit3.TestAdapter.dll" />

--- a/src/NUnitTestAdapter/EmbeddedAssemblyResolution.cs
+++ b/src/NUnitTestAdapter/EmbeddedAssemblyResolution.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+#if NETCOREAPP1_0
+using System.Runtime.Loader;
+#endif
+
+namespace NUnit.VisualStudio.TestAdapter
+{
+    internal static class EmbeddedAssemblyResolution
+    {
+        private static readonly object lockObj = new object();
+        private static bool isInitialized;
+
+        public static void EnsureInitialized()
+        {
+            if (isInitialized) return;
+
+            lock (lockObj)
+            {
+                if (isInitialized) return;
+
+#if NET35
+                AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+#else
+                AssemblyLoadContext.Default.Resolving += Default_Resolving;
+#endif
+
+                isInitialized = true;
+            }
+        }
+
+#if NET35
+        private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            using (var stream = TryGetResourceAssemblyStream(new AssemblyName(args.Name)))
+            {
+                return stream == null ? null : Assembly.Load(stream.ReadToEnd());
+            }
+        }
+#else
+        private static Assembly Default_Resolving(AssemblyLoadContext context, AssemblyName name)
+        {
+            using (var stream = TryGetResourceAssemblyStream(name))
+            {
+                if (stream == null) return null;
+                return context.LoadFromStream(stream);
+            }
+        }
+#endif
+
+        private static readonly string[] AllowedResourceAssemblyNames =
+        {
+            "Mono.Cecil"
+        };
+
+        private static Stream TryGetResourceAssemblyStream(AssemblyName assemblyName)
+        {
+            var properCasing = AllowedResourceAssemblyNames.FirstOrDefault(name =>
+                name.Equals(assemblyName.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (properCasing == null) return null;
+
+            return typeof(EmbeddedAssemblyResolution)
+#if NETCOREAPP1_0
+                .GetTypeInfo()
+#endif
+                .Assembly.GetManifestResourceStream(@"Assemblies\" + properCasing + ".dll");
+        }
+
+#if NET35
+        private static byte[] ReadToEnd(this Stream stream)
+        {
+            if (stream == null) throw new ArgumentNullException(nameof(stream));
+            if (!stream.CanRead) throw new ArgumentException("Stream must be readable.", nameof(stream));
+            if (!stream.CanSeek) throw new ArgumentException("Stream must be seekable.", nameof(stream));
+
+            var array = new byte[stream.Length - stream.Position];
+
+            var position = 0;
+            for (int bytesRead; position < array.Length; position += bytesRead)
+            {
+                bytesRead = stream.Read(array, position, array.Length - position);
+                if (bytesRead == 0) break;
+            }
+
+            if (position == array.Length) return array;
+
+            var resized = new byte[position];
+            Array.Copy(array, resized, position);
+            return resized;
+        }
+#endif
+    }
+}

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -49,4 +49,12 @@
     </ItemGroup>
   </Target>
 
+  <!-- Before RemoveReferencesToEmbeddedAssembles (our thing in Common.props which disappears the ReferencePath that we need here). -->
+  <Target Name="AddReferencesAsEmbeddedResources" BeforeTargets="RemoveReferencesToEmbeddedAssembles">
+    <ItemGroup>
+      <!-- Add Mono.Cecil.dll as an embedded reference named ‘Assemblies\Mono.Cecil.dll’ -->
+      <EmbeddedResource Include="@(ReferencePath)" Condition="'%(Filename)' == 'Mono.Cecil'" KeepMetadata="x" LogicalName="Assemblies\%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -46,6 +46,11 @@ namespace NUnit.VisualStudio.TestAdapter
     [Category("managed")]
     public sealed class NUnit3TestDiscoverer : NUnitTestAdapter, ITestDiscoverer
     {
+        public NUnit3TestDiscoverer()
+        {
+            EmbeddedAssemblyResolution.EnsureInitialized();
+        }
+
         private Dump.DumpXml dumpXml;
 
         #region ITestDiscoverer Members
@@ -58,7 +63,7 @@ namespace NUnit.VisualStudio.TestAdapter
 #endif
             Initialize(discoveryContext, messageLogger);
 
-            
+
 
             TestLog.Info($"NUnit Adapter {AdapterVersion}: Test discovery starting");
 
@@ -81,9 +86,9 @@ namespace NUnit.VisualStudio.TestAdapter
                 if (Settings.DumpXmlTestDiscovery)
                 {
                     dumpXml = new DumpXml(sourceAssemblyPath);
-                    
+
                 }
-               
+
                 try
                 {
                     runner = GetRunnerFor(sourceAssemblyPath);
@@ -119,7 +124,7 @@ namespace NUnit.VisualStudio.TestAdapter
                         else
                             TestLog.Info("NUnit failed to load " + sourceAssembly);
                     }
-                    
+
                 }
                 catch (BadImageFormatException)
                 {

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -41,6 +41,11 @@ namespace NUnit.VisualStudio.TestAdapter
     [ExtensionUri(ExecutorUri)]
     public sealed class NUnit3TestExecutor : NUnitTestAdapter, ITestExecutor, IDisposable
     {
+        public NUnit3TestExecutor()
+        {
+            EmbeddedAssemblyResolution.EnsureInitialized();
+        }
+
         // Fields related to the currently executing assembly
         private ITestRunner _activeRunner;
 
@@ -286,7 +291,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     else
                         TestLog.Info("NUnit failed to load " + assemblyPath);
                 }
-              
+
             }
             catch (BadImageFormatException)
             {

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/Isolated package cache

--- a/tests/Referencing Mono.Cecil 0.10.0/Referencing Mono.Cecil 0.10.0.csproj
+++ b/tests/Referencing Mono.Cecil 0.10.0/Referencing Mono.Cecil 0.10.0.csproj
@@ -2,18 +2,27 @@
 
   <PropertyGroup>
     <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
-    <RootNamespace>Referencing_Mono_Cecil</RootNamespace>
+    <RootNamespace>Referencing_Mono_Cecil_0_10_0</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta5" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
     <PackageReference Include="NUnit" Version="*" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
+    <PackageReference Include="nunit.engine.api" Version="3.7.0" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="*" />
+    <PackageReference Include="nunit.engine.netstandard" Version="3.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="test.addins" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
 </Project>

--- a/tests/Referencing Mono.Cecil 0.10.0/ReferencingMonoCecilTests.cs
+++ b/tests/Referencing Mono.Cecil 0.10.0/ReferencingMonoCecilTests.cs
@@ -2,14 +2,14 @@
 using System.Reflection;
 using NUnit.Framework;
 
-namespace Referencing_Mono_Cecil
+namespace Referencing_Mono_Cecil_0_10_0
 {
     public class ReferencingMonoCecilTests
     {
         [Test]
         public void UsesCorrectVersionOfMonoCecil()
         {
-            const string versionNotUsedByNUnit = "0.10.0.0-beta5";
+            const string versionNotUsedByNUnit = "0.10.0.0";
 
             var assembly = typeof(Mono.Cecil.ReaderParameters)
 #if NETCOREAPP1_0

--- a/tests/Referencing Mono.Cecil 0.10.0/TestNUnitEngineExtension.cs
+++ b/tests/Referencing Mono.Cecil 0.10.0/TestNUnitEngineExtension.cs
@@ -1,0 +1,17 @@
+﻿using NUnit.Engine;
+using NUnit.Engine.Extensibility;
+
+namespace Referencing_Mono_Cecil_0_10_0
+{
+    // Trigger Mono.Cecil binary break between older versions and 0.10.0
+    // (test.addins points the engine to search all classes in this file and should result
+    // in a runtime failure to cast 'Mono.Cecil.InterfaceImplementation' to 'Mono.Cecil.TypeReference'
+    // if the engine is using the newer version of Mono.Cecil)
+    [Extension]
+    public sealed class TestNUnitEngineExtension : ITestEventListener
+    {
+        public void OnTestEvent(string report)
+        {
+        }
+    }
+}

--- a/tests/Referencing Mono.Cecil 0.10.0/test.addins
+++ b/tests/Referencing Mono.Cecil 0.10.0/test.addins
@@ -1,0 +1,1 @@
+﻿Referencing Mono.Cecil 0.10.0.dll

--- a/tests/Referencing Mono.Cecil/Referencing Mono.Cecil.csproj
+++ b/tests/Referencing Mono.Cecil/Referencing Mono.Cecil.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
+    <RootNamespace>Referencing_Mono.Cecil</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta5" />
+    <PackageReference Include="NUnit" Version="*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+    <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="*" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Referencing Mono.Cecil/ReferencingMonoCecilTests.cs
+++ b/tests/Referencing Mono.Cecil/ReferencingMonoCecilTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Referencing_Mono.Cecil
+{
+    public class ReferencingMonoCecilTests
+    {
+        [Test]
+        public void UsesCorrectVersionOfMonoCecil()
+        {
+            const string versionNotUsedByNUnit = "0.10.0.0-beta5";
+
+            var assembly = typeof(Mono.Cecil.ReaderParameters)
+#if NETCOREAPP1_0
+                .GetTypeInfo()
+#endif
+                .Assembly;
+
+            var versionBlock = FileVersionInfo.GetVersionInfo(assembly.Location);
+
+            Assert.That(versionBlock.ProductVersion, Is.EqualTo(versionNotUsedByNUnit));
+        }
+    }
+}

--- a/tests/Simple/Simple.csproj
+++ b/tests/Simple/Simple.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
+    <PackageReference Include="NUnit" Version="*" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Simple/SimpleTests.cs
+++ b/tests/Simple/SimpleTests.cs
@@ -1,0 +1,13 @@
+﻿using NUnit.Framework;
+
+namespace Simple
+{
+    public class SimpleTests
+    {
+        [Test]
+        public void PassingTest()
+        {
+            Assert.Pass();
+        }
+    }
+}

--- a/tests/Tests.sln
+++ b/tests/Tests.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 15.0.28010.2003
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Simple", "Simple\Simple.csproj", "{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Referencing Mono.Cecil", "Referencing Mono.Cecil\Referencing Mono.Cecil.csproj", "{156FD4D7-B142-4F42-9886-13565A590591}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Referencing Mono.Cecil", "Referencing Mono.Cecil\Referencing Mono.Cecil.csproj", "{156FD4D7-B142-4F42-9886-13565A590591}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Referencing Mono.Cecil 0.10.0", "Referencing Mono.Cecil 0.10.0\Referencing Mono.Cecil 0.10.0.csproj", "{3CB8B8C0-2188-4320-B061-E77AF66F8ACF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{156FD4D7-B142-4F42-9886-13565A590591}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{156FD4D7-B142-4F42-9886-13565A590591}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{156FD4D7-B142-4F42-9886-13565A590591}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CB8B8C0-2188-4320-B061-E77AF66F8ACF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CB8B8C0-2188-4320-B061-E77AF66F8ACF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CB8B8C0-2188-4320-B061-E77AF66F8ACF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CB8B8C0-2188-4320-B061-E77AF66F8ACF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/Tests.sln
+++ b/tests/Tests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2003
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Simple", "Simple\Simple.csproj", "{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CAEB3AC6-D000-4CF4-AD64-80DEE03CEA75}
+	EndGlobalSection
+EndGlobal

--- a/tests/Tests.sln
+++ b/tests/Tests.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28010.2003
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Simple", "Simple\Simple.csproj", "{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Referencing Mono.Cecil", "Referencing Mono.Cecil\Referencing Mono.Cecil.csproj", "{156FD4D7-B142-4F42-9886-13565A590591}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C5616DBC-FBD9-4E41-8BE3-9D3D4C00092C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{156FD4D7-B142-4F42-9886-13565A590591}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{156FD4D7-B142-4F42-9886-13565A590591}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{156FD4D7-B142-4F42-9886-13565A590591}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{156FD4D7-B142-4F42-9886-13565A590591}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/nuget.config
+++ b/tests/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="globalPackagesFolder" value="Isolated package cache" />
+  </config>
+  <packageSources>
+    <add key="Build script package output" value="..\package" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Closes nunit/nunit-console#389, #366, and #488 for all platforms! Pretty excited about this after all our frustrations! 🎉

The first commit adds a simple passing acceptance test that proves the adapter is packaged basically correctly. The acceptance tests hardly add any time on my machine after a `git clean -xfd`, despite having to cache all NuGet packages from scratch.

The third commit adds a failing test asserting that the test project's desired version of Mono.Cecil has been loaded, which is the problem discussed in nunit/nunit-console#389, #366, and #488.

The fourth commit fixes the problem by embedding Mono.Cecil as an adapter assembly resource and resolving it on demand.