### PR TITLE
Preparing for release of 3.11

### DIFF
--- a/NUnit3TestAdapter.sln
+++ b/NUnit3TestAdapter.sln
@@ -36,6 +36,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NUnit3TestAdapterInstall", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NUnit3AdapterExternalTests", "src\NUnit3AdapterExternalTests\NUnit3AdapterExternalTests.csproj", "{A4EA819A-D77D-46D3-B2B7-2C754DBD2BC7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "net35", "net35", "{EAA35582-E3FE-49A8-896A-4FF60114ECD4}"
+	ProjectSection(SolutionItems) = preProject
+		nuget\net35\NUnit3TestAdapter.props = nuget\net35\NUnit3TestAdapter.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcore1", "netcore1", "{60BCE6EE-FB99-47BC-AFDD-10B93C8A3AA4}"
+	ProjectSection(SolutionItems) = preProject
+		nuget\netcoreapp1.0\NUnit3TestAdapter.props = nuget\netcoreapp1.0\NUnit3TestAdapter.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +79,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EAA35582-E3FE-49A8-896A-4FF60114ECD4} = {DE347D88-F6ED-4031-AFC2-318F63E39BC9}
+		{60BCE6EE-FB99-47BC-AFDD-10B93C8A3AA4} = {DE347D88-F6ED-4031-AFC2-318F63E39BC9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8EF03474-188E-44A8-8C76-9FBCF9A382EC}

--- a/build.cake
+++ b/build.cake
@@ -110,7 +110,10 @@ Task("NuGetRestore")
         Configuration = configuration,
         Verbosity = Verbosity.Minimal,
         ToolVersion = MSBuildToolVersion.VS2017
-    }.WithTarget("Restore"));
+    }
+    .WithTarget("Restore")
+    // Workaround for https://github.com/Microsoft/msbuild/issues/3626
+    .WithProperty("AddSyntheticProjectReferencesForSolutionDependencies", "false"));
 });
 
 //////////////////////////////////////////////////////////////////////
@@ -138,7 +141,9 @@ Task("Build")
             {
                 ["PackageVersion"] = packageVersion
             }
-        });
+        }
+        // Workaround for https://github.com/Microsoft/msbuild/issues/3626
+        .WithProperty("AddSyntheticProjectReferencesForSolutionDependencies", "false"));
     });
 
 //////////////////////////////////////////////////////////////////////

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -13,7 +13,7 @@
         <summary>NUnit 3 adapter for running tests in Visual Studio. Works with NUnit 3.x, use the NUnit 2 adapter for 2.x tests.</summary>
         <description>A package including the NUnit 3 TestAdapter for Visual Studio 2012 onwards.  With this package you don't need to install the VSIX adapter package, and you don't need to upload the adapter to your TFS server.
 
-Note that this package ONLY contains the adapter, not the NUnit framework.  You must also get the framework. You only need one such package for a solution.
+Note that this package ONLY contains the adapter, not the NUnit framework.  You must also get the framework. For VS 2017 and forward you should add this package to every test project in your solution, earlier version only require a single adapter package.
 
 The package works with Visual Studio 2012 and newer.</description>
         <releaseNotes>This release works with NUnit 3.0 and higher only.  Also see  https://github.com/nunit/docs/wiki/Adapter-Release-Notes  </releaseNotes>

--- a/src/NUnit3AdapterExternalTests/NUnit3AdapterExternalTests.csproj
+++ b/src/NUnit3AdapterExternalTests/NUnit3AdapterExternalTests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>NUnit.VisualStudio.TestAdapter.ExternalTests</AssemblyName>
     <RootNamespace>NUnit.VisualStudio.TestAdapter.Tests</RootNamespace>
     <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnit3AdapterExternalTests/NUnit3AdapterExternalTests.csproj
+++ b/src/NUnit3AdapterExternalTests/NUnit3AdapterExternalTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine.netstandard" Version="3.8.0" />
+    <PackageReference Include="nunit.engine.netstandard" Version="3.7.0" />
   </ItemGroup>
 
   <Target Name="PreventTestPlatformObjectModelCopyLocal" AfterTargets="ResolveReferences">

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -34,14 +34,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.7.0" />
+    <PackageReference Include="nunit.engine" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine.netstandard" Version="3.7.0" />
+    <PackageReference Include="nunit.engine.netstandard" Version="3.8.0" />
   </ItemGroup>
 
   <Target Name="PreventTestPlatformObjectModelCopyLocal" AfterTargets="ResolveReferences">

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.9.0" />
+    <PackageReference Include="nunit.engine" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>NUnit.VisualStudio.TestAdapter</RootNamespace>
     <!--<TargetFramework>net35</TargetFramework>--><!-- For testing and debugging-->
     <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
+    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
     <CodeAnalysisRuleSet>..\..\Osiris.Extended.ruleset</CodeAnalysisRuleSet>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SourceLinkOriginUrl>https://github.com/nunit/nunit3-vs-adapter</SourceLinkOriginUrl>

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -28,12 +28,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.7.0" />
+    <PackageReference Include="nunit.engine" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine.netstandard" Version="3.7.0" />
+    <PackageReference Include="nunit.engine.netstandard" Version="3.8.0" />
   </ItemGroup>
 
   <Target Name="PreventTestPlatformObjectModelCopyLocal" AfterTargets="ResolveReferences">

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -119,8 +119,13 @@ namespace NUnit.VisualStudio.TestAdapter
                     else
                     {
                         var msgNode = topNode.SelectSingleNode("properties/property[@name='_SKIPREASON']");
-                        if (msgNode != null && (new[] { "contains no tests", "Has no TestFixtures" }).Any(msgNode.GetAttribute("value").Contains))
-                            TestLog.Info("Assembly contains no NUnit 3.0 tests: " + sourceAssembly);
+                        if (msgNode != null &&
+                            (new[] {"contains no tests", "Has no TestFixtures"}).Any(msgNode.GetAttribute("value")
+                                .Contains))
+                        {
+                            if (Settings.Verbosity>0)
+                                TestLog.Info("Assembly contains no NUnit 3.0 tests: " + sourceAssembly);
+                        }
                         else
                             TestLog.Info("NUnit failed to load " + sourceAssembly);
                     }

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -253,7 +253,7 @@ namespace NUnit.VisualStudio.TestAdapter
                             loadedTestCases.Add(testConverter.ConvertTestCase(testNode));
 
 
-                        TestLog.Info($"NUnit3TestExecutor converted {loadedTestCases.Count} of {nunitTestCases.Count} NUnit test cases");
+                        TestLog.Info($"   NUnit3TestExecutor converted {loadedTestCases.Count} of {nunitTestCases.Count} NUnit test cases");
 
                         // If we have a TFS Filter, convert it to an nunit filter
                         if (TfsFilter != null && !TfsFilter.IsEmpty)
@@ -265,7 +265,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
                         if (filter == NUnitTestFilterBuilder.NoTestsFound)
                         {
-                            TestLog.Info("Skipping assembly - no matching test cases found");
+                            TestLog.Info("   Skipping assembly - no matching test cases found");
                             return;
                         }
 
@@ -278,7 +278,7 @@ namespace NUnit.VisualStudio.TestAdapter
                             catch (NullReferenceException)
                             {
                                 // this happens during the run when CancelRun is called.
-                                TestLog.Debug("Nullref caught");
+                                TestLog.Debug("   Nullref caught");
                             }
                         }
                     }
@@ -287,27 +287,27 @@ namespace NUnit.VisualStudio.TestAdapter
                 {
                     var msgNode = loadResult.SelectSingleNode("properties/property[@name='_SKIPREASON']");
                     if (msgNode != null && (new[] { "contains no tests", "Has no TestFixtures" }).Any(msgNode.GetAttribute("value").Contains))
-                        TestLog.Info("NUnit couldn't find any tests in " + assemblyPath);
+                        TestLog.Info("   NUnit couldn't find any tests in " + assemblyPath);
                     else
-                        TestLog.Info("NUnit failed to load " + assemblyPath);
+                        TestLog.Info("   NUnit failed to load " + assemblyPath);
                 }
 
             }
             catch (BadImageFormatException)
             {
                 // we skip the native c++ binaries that we don't support.
-                TestLog.Warning("Assembly not supported: " + assemblyPath);
+                TestLog.Warning("   Assembly not supported: " + assemblyPath);
             }
             catch (FileNotFoundException ex)
             {
                 // Probably from the GetExportedTypes in NUnit.core, attempting to find an assembly, not a problem if it is not NUnit here
-                TestLog.Warning("Dependent Assembly " + ex.FileName + " of " + assemblyPath + " not found. Can be ignored if not a NUnit project.");
+                TestLog.Warning("   Dependent Assembly " + ex.FileName + " of " + assemblyPath + " not found. Can be ignored if not a NUnit project.");
             }
             catch (Exception ex)
             {
                 if (ex is TargetInvocationException)
                     ex = ex.InnerException;
-                TestLog.Warning("Exception thrown executing tests in " + assemblyPath, ex);
+                TestLog.Warning("   Exception thrown executing tests in " + assemblyPath, ex);
             }
             finally
             {
@@ -324,7 +324,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     // can happen if CLR throws CannotUnloadAppDomainException, for example
                     // due to a long-lasting operation in a protected region (catch/finally clause).
                     if (ex is TargetInvocationException) { ex = ex.InnerException; }
-                    TestLog.Warning("Exception thrown unloading tests from " + assemblyPath, ex);
+                    TestLog.Warning("   Exception thrown unloading tests from " + assemblyPath, ex);
                 }
             }
         }

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -99,7 +99,8 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public void Info(string message)
         {
-            SendMessage(TestMessageLevel.Informational, message);
+            if (adapterSettings?.Verbosity>= 0)
+                SendMessage(TestMessageLevel.Informational, message);
         }
 
         #endregion
@@ -119,8 +120,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         public void SendMessage(TestMessageLevel testMessageLevel, string message)
         {
-            if (MessageLogger != null)
-                MessageLogger.SendMessage(testMessageLevel, message);
+            MessageLogger?.SendMessage(testMessageLevel, message);
         }
 
         public void SendMessage(TestMessageLevel testMessageLevel, string message, Exception ex)

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>NUnit.VisualStudio.TestAdapter.Tests</RootNamespace>
     <AssemblyName>NUnit.VisualStudio.TestAdapter.Tests</AssemblyName>
     <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
     <!--<TargetFrameworks>net46</TargetFrameworks>-->     <!-- For testing and debugging-->
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -12,8 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -53,8 +53,6 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 
         List<TestCase> TestCases;
 
-        private static ITestDiscoverer nunittestDiscoverer;
-
         private IDiscoveryContext _context;
 
         public TestDiscoveryTests(IDiscoveryContext context)

--- a/src/empty-assembly/empty-assembly.csproj
+++ b/src/empty-assembly/empty-assembly.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>empty-assembly</AssemblyName>
     <RootNamespace>NUnit.Tests</RootNamespace>
     <TargetFrameworks>net35;netstandard1.6</TargetFrameworks>
+    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
     <DebugType Condition="'$(TargetFramework)' != '' AND '$(TargetFramework)' != 'netstandard1.6'">Full</DebugType>
   </PropertyGroup>
 

--- a/src/empty-assembly/empty-assembly.csproj
+++ b/src/empty-assembly/empty-assembly.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/mock-assembly/mock-assembly.csproj
+++ b/src/mock-assembly/mock-assembly.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/mock-assembly/mock-assembly.csproj
+++ b/src/mock-assembly/mock-assembly.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>mock-assembly</AssemblyName>
     <RootNamespace>NUnit.Tests</RootNamespace>
     <TargetFrameworks>net35;netstandard1.6</TargetFrameworks>
+    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hiding warnings for assemblies without tests which triggers also on non-test assemblies, so this reduces some noise
It now looks like this, and all these are non-test assemblies
![image](https://user-images.githubusercontent.com/203432/47268726-baa2ca00-d554-11e8-8335-536544b4ced0.png)
