### PR TITLE
Update to NUnit.Engine 3.9.0, and netstandard engine 3.8.0

### DIFF
--- a/acceptance.cake
+++ b/acceptance.cake
@@ -14,9 +14,9 @@ Task("Acceptance")
 
         using (var tempDirectory = new TempDirectory())
         {
-            BuildAndVerifySinglePassingTest("Simple", "net35", "netcoreapp1.0");
-            BuildAndVerifySinglePassingTest("Referencing Mono.Cecil", "net35", "netcoreapp1.0");
-            BuildAndVerifySinglePassingTest("Referencing Mono.Cecil 0.10.0", "net35", "netcoreapp1.0");
+            BuildAndVerifySinglePassingTest("Simple", "net40", "netcoreapp1.0");
+            BuildAndVerifySinglePassingTest("Referencing Mono.Cecil", "net40", "netcoreapp1.0");
+            BuildAndVerifySinglePassingTest("Referencing Mono.Cecil 0.10.0", "net40", "netcoreapp1.0");
 
             void BuildAndVerifySinglePassingTest(string projectName, params string[] targetFrameworks)
             {

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -23,6 +23,10 @@
     <Authors>Charlie Poole, Terje Sandstrom</Authors>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
+    <DisableHandlePackageFileConflicts>false</DisableHandlePackageFileConflicts>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="..\..\LICENSE.txt" Link="LICENSE.txt" />
   </ItemGroup>

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -33,14 +33,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.7.0" />
+    <PackageReference Include="nunit.engine" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine.netstandard" Version="3.7.0" />
+    <PackageReference Include="nunit.engine.netstandard" Version="3.8.0" />
   </ItemGroup>
 
   <Target Name="PreventTestPlatformObjectModelCopyLocal" AfterTargets="ResolveReferences">

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35'">
+    <!-- Suppress errors from https://github.com/dotnet/sdk/issues/1897-->
     <DisableHandlePackageFileConflicts>false</DisableHandlePackageFileConflicts>
   </PropertyGroup>
 

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -113,7 +113,7 @@ namespace NUnit.VisualStudio.TestAdapter
                         // Only save if seed is not specified in runsettings
                         // This allows workaround in case there is no valid
                         // location in which the seed may be saved.
-                        if (cases>0 && !Settings.RandomSeedSpecified)
+                        if (cases > 0 && !Settings.RandomSeedSpecified)
                             Settings.SaveRandomSeed(Path.GetDirectoryName(sourceAssemblyPath));
                     }
                     else
@@ -123,13 +123,25 @@ namespace NUnit.VisualStudio.TestAdapter
                             (new[] {"contains no tests", "Has no TestFixtures"}).Any(msgNode.GetAttribute("value")
                                 .Contains))
                         {
-                            if (Settings.Verbosity>0)
+                            if (Settings.Verbosity > 0)
                                 TestLog.Info("Assembly contains no NUnit 3.0 tests: " + sourceAssembly);
                         }
                         else
                             TestLog.Info("NUnit failed to load " + sourceAssembly);
                     }
 
+                }
+                catch (NUnitEngineException e)
+                {
+                    if (e.InnerException is BadImageFormatException)
+                    {
+                        // we skip the native c++ binaries that we don't support.
+                        TestLog.Warning("Assembly not supported: " + sourceAssembly);
+                    }
+                    else
+                    {
+                        TestLog.Warning("Exception thrown discovering tests in " + sourceAssembly, e);
+                    }
                 }
                 catch (BadImageFormatException)
                 {

--- a/tests/Referencing Mono.Cecil 0.10.0/Referencing Mono.Cecil 0.10.0.csproj
+++ b/tests/Referencing Mono.Cecil 0.10.0/Referencing Mono.Cecil 0.10.0.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
     <RootNamespace>Referencing_Mono_Cecil_0_10_0</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Referencing Mono.Cecil 0.10.0/Referencing Mono.Cecil 0.10.0.csproj
+++ b/tests/Referencing Mono.Cecil 0.10.0/Referencing Mono.Cecil 0.10.0.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp1.0</TargetFrameworks>
     <RootNamespace>Referencing_Mono_Cecil_0_10_0</RootNamespace>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -13,7 +13,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <PackageReference Include="nunit.engine.api" Version="3.7.0" />
   </ItemGroup>
 

--- a/tests/Referencing Mono.Cecil 0.10.0/Referencing Mono.Cecil 0.10.0.csproj
+++ b/tests/Referencing Mono.Cecil 0.10.0/Referencing Mono.Cecil 0.10.0.csproj
@@ -14,12 +14,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <PackageReference Include="nunit.engine.api" Version="3.7.0" />
+    <PackageReference Include="nunit.engine.api" Version="3.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="*" />
-    <PackageReference Include="nunit.engine.netstandard" Version="3.7.0" />
+    <PackageReference Include="nunit.engine.netstandard" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Referencing Mono.Cecil/Referencing Mono.Cecil.csproj
+++ b/tests/Referencing Mono.Cecil/Referencing Mono.Cecil.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
     <RootNamespace>Referencing_Mono_Cecil</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Referencing Mono.Cecil/Referencing Mono.Cecil.csproj
+++ b/tests/Referencing Mono.Cecil/Referencing Mono.Cecil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp1.0</TargetFrameworks>
     <RootNamespace>Referencing_Mono_Cecil</RootNamespace>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/Simple/Simple.csproj
+++ b/tests/Simple/Simple.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Simple/Simple.csproj
+++ b/tests/Simple/Simple.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net40;netcoreapp1.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 


### PR DESCRIPTION
https://github.com/nunit/nunit-console/pull/479 will introduce some major changes to the engine, which we'll want to test with the adapter before merging.

I spotted the adapter is currently using a version of the engine a few behind the current release. To make the transition easier, I wanted to first update it to the latest released version, before trying to pull in the new changes. 

The update has required a few changes, which I'll line comment below. The acceptance tests are currently failing, but I've ran out of time for today and will need to get back to these. (@jnm2 - I understand these are something you added recently - if there's anything that jumps out to you that I should check out, I'd appreciate the tips!)