### PR TITLE
Fix for issue #559  and #561 

### DIFF
--- a/NUnit3TestAdapter.sln
+++ b/NUnit3TestAdapter.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.Config = NuGet.Config
 		Osiris.Extended.ruleset = Osiris.Extended.ruleset
 		README.md = README.md
+		Simple.runsettings = Simple.runsettings
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{DE347D88-F6ED-4031-AFC2-318F63E39BC9}"

--- a/Simple.runsettings
+++ b/Simple.runsettings
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- 0 = As many processes as possible, limited by number of cores on machine, 1 = Sequential (1 process), 2-> Given number of processes up to limit by number of cores on machine-->
+    <MaxCpuCount>0</MaxCpuCount>
+  </RunConfiguration>
+
+    <!--
+    <TestRunParameters>
+        <Parameter name="webAppUrl" value="http://localhost" />
+        <Parameter name="webAppUserName" value="Admin" />
+    </TestRunParameters>
+-->
+
+    <!-- Adapter Specific sections -->
+
+    <!-- MSTest adapter -->
+    <MSTest>
+        <MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+        <CaptureTraceOutput>false</CaptureTraceOutput>
+        <DeleteDeploymentDirectoryAfterTestRunIsComplete>False</DeleteDeploymentDirectoryAfterTestRunIsComplete>
+        <DeploymentEnabled>False</DeploymentEnabled>
+        <!-- Uncomment and update path for assembly resolution  -->
+        <!--  <AssemblyResolution>    
+             <Directory path="D:\myfolder\bin\" includeSubDirectories="false"/>
+   </AssemblyResolution>  -->
+    </MSTest>
+
+    <!-- NUnit3 adapter, uncomment to set as appropriate, numeric, booleans, enums have their default values below, except RandomSeed -->
+    <!--
+    <NUnit>
+        <BasePath>D:\Dev\NUnit\nunit3-vs-adapter\demo\NUnitTestDemo\bin\Release</BasePath>
+        <PrivateBinPath>extras;more.extras</PrivateBinPath>
+        <DefaultTimeout>0</DefaultTimeout>
+        <WorkDirectory>work</WorkDirectory>
+        <InternalTraceLevel>Off</InternalTraceLevel>
+        <RandomSeed>1234567</RandomSeed>  
+        <NumberOfTestWorkers>-1</NumberOfTestWorkers>
+        <Verbosity>0</Verbosity>
+        <UseVsKeepEngineRunning>false</UseVsKeepEngineRunning>
+        <ShadowCopyFiles>false</ShadowCopyFiles>
+        <DefaultTestNamePattern>{m}{a}</DefaultTestNamePattern>
+    </NUnit>
+    -->
+
+    <NUnit>
+        <Verbosity>0</Verbosity>
+    </NUnit>
+
+
+</RunSettings>
+

--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var configuration = Argument("configuration", "Release");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "3.11.0";
+var version = "3.11.1";
 var modifier = "";
 
 var dbgSuffix = configuration == "Debug" ? "-dbg" : "";

--- a/build.ps1
+++ b/build.ps1
@@ -32,8 +32,8 @@ Param(
 )
 
 $CakeVersion = "0.30.0"
-# $DotNetVersion = "2.1.201";   # This will not work with the tests
-$DotNetVersion = "1.0.4";
+ $DotNetVersion = "2.1.201";   # This will not work with the tests
+# $DotNetVersion = "1.0.4";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,8 @@ Param(
 )
 
 $CakeVersion = "0.30.0"
-$DotNetVersion = "2.1.201";
+# $DotNetVersion = "2.1.201";   # This will not work with the tests
+$DotNetVersion = "1.0.4";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 
@@ -80,6 +81,7 @@ if($FoundDotNetCliVersion -ne $DotNetVersion) {
     if (!(Test-Path $InstallPath)) {
         mkdir -Force $InstallPath | Out-Null;
     }
+    [Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
     & $InstallPath\dotnet-install.ps1 -Version $DotNetVersion -InstallDir $InstallPath;
 

--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -61,11 +61,20 @@ namespace NUnit.VisualStudio.TestAdapter
         /// </summary>
         string DefaultTestNamePattern { get; }
 
+        VsTestCategoryType VsTestCategoryType { get; }
+
         void Load(IDiscoveryContext context);
         void Load(string settingsXml);
         void SaveRandomSeed(string dirname);
         void RestoreRandomSeed(string dirname);
     }
+
+    public enum VsTestCategoryType
+    {
+        NUnit,
+        MsTest
+    }
+
 
     public class AdapterSettings : IAdapterSettings
     {
@@ -153,6 +162,8 @@ namespace NUnit.VisualStudio.TestAdapter
         public string DomainUsage { get; private set; }
 
 
+        public VsTestCategoryType VsTestCategoryType { get; private set; } = VsTestCategoryType.MsTest;
+
         public bool DumpXmlTestDiscovery { get; private set; }
 
         public bool DumpXmlTestResults { get; private set; }
@@ -226,6 +237,20 @@ namespace NUnit.VisualStudio.TestAdapter
 
             DumpXmlTestDiscovery = GetInnerTextAsBool(nunitNode, nameof(DumpXmlTestDiscovery), false);
             DumpXmlTestResults = GetInnerTextAsBool(nunitNode, nameof(DumpXmlTestResults), false);
+            var vsTestCategoryType = GetInnerText(nunitNode, nameof(VsTestCategoryType), Verbosity > 0);
+            if (vsTestCategoryType != null)
+                switch (vsTestCategoryType.ToLower())
+                {
+                    case "nunit":
+                        VsTestCategoryType = VsTestCategoryType.NUnit;
+                        break;
+                    case "mstest":
+                        VsTestCategoryType = VsTestCategoryType.MsTest;
+                        break;
+                    default:
+                        _logger.Warning($"Invalid value ({vsTestCategoryType}) for VsTestCategoryType, should be either NUnit or MsTest");
+                        break;
+                }
 
 
 
@@ -348,8 +373,7 @@ namespace NUnit.VisualStudio.TestAdapter
                         if (string.Compare(valid, val, StringComparison.OrdinalIgnoreCase) == 0)
                             return valid;
 
-                    throw new ArgumentException(string.Format(
-                        "Invalid value {0} passed for element {1}.", val, xpath));
+                    throw new ArgumentException($"Invalid value {val} passed for element {xpath}.");
                 }
 
 

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -104,7 +104,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     if (topNode.GetAttribute("runstate") == "Runnable")
                     {
                         int cases;
-                        using (var testConverter = new TestConverter(TestLog, sourceAssemblyPath, Settings.CollectSourceInformation))
+                        using (var testConverter = new TestConverter(TestLog, sourceAssemblyPath, Settings))
                         {
                             cases = ProcessTestCases(topNode, discoverySink, testConverter);
                         }

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -242,7 +242,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 {
                     var nunitTestCases = loadResult.SelectNodes("//test-case");
 
-                    using (var testConverter = new TestConverter(TestLog, assemblyPath, Settings.CollectSourceInformation))
+                    using (var testConverter = new TestConverter(TestLog, assemblyPath, Settings))
                     {
                         var loadedTestCases = new List<TestCase>();
 

--- a/src/NUnitTestAdapter/TraitsFeature.cs
+++ b/src/NUnitTestAdapter/TraitsFeature.cs
@@ -60,11 +60,11 @@ namespace NUnit.VisualStudio.TestAdapter
         }
 
         public static void AddTraitsFromTestNode(this TestCase testCase, XmlNode testNode,
-            IDictionary<string, CachedTestCaseInfo> traitsCache, ITestLogger logger)
+            IDictionary<string, CachedTestCaseInfo> traitsCache, ITestLogger logger, IAdapterSettings adapterSettings)
         {
             var ancestor = testNode.ParentNode;
             var key = ancestor.Attributes?["id"]?.Value;
-            var categorylist = new CategoryList(testCase);
+            var categorylist = new CategoryList(testCase,adapterSettings);
             // Reading ancestor properties of a test-case node. And adding to the cache.
             while (ancestor != null && key != null)
             {

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -221,6 +221,22 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(_settings.BasePath, Is.EqualTo(".."));
         }
 
+
+        [Test]
+        public void VsTestCategoryTypeSetting()
+        {
+            _settings.Load("<RunSettings><NUnit><VsTestCategoryType>nunit</VsTestCategoryType></NUnit></RunSettings>");
+            Assert.That(_settings.VsTestCategoryType, Is.EqualTo(VsTestCategoryType.NUnit));
+        }
+
+        [Test]
+        public void VsTestCategoryTypeSettingWithGarbage()
+        {
+            _settings.Load("<RunSettings><NUnit><VsTestCategoryType>garbage</VsTestCategoryType></NUnit></RunSettings>");
+            Assert.That(_settings.VsTestCategoryType, Is.EqualTo(VsTestCategoryType.MsTest));
+        }
+
+
         [Test]
         public void PrivateBinPathSetting()
         {

--- a/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
@@ -52,8 +52,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void SetUp()
         {
             testLog = new FakeFrameworkHandle();
-
-            using (var testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath, collectSourceInformation: true))
+            var settings = Substitute.For<IAdapterSettings>();
+            settings.CollectSourceInformation.Returns(true);
+            using (var testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath,settings))
             {
                 fakeTestNode = FakeTestData.GetTestNode();
 
@@ -154,7 +155,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void Listener_LeaseLifetimeWillNotExpire()
         {
             testLog = new FakeFrameworkHandle();
-            using (var testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath, collectSourceInformation: true))
+            var settings = Substitute.For<IAdapterSettings>();
+            settings.CollectSourceInformation.Returns(true);
+            using (var testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath, settings))
             {
                 var localInstance = (MarshalByRefObject)Activator.CreateInstance(typeof(NUnitEventListener), testLog, testConverter, null);
 

--- a/src/NUnitTestAdapterTests/TestCaseUtils.cs
+++ b/src/NUnitTestAdapterTests/TestCaseUtils.cs
@@ -25,6 +25,7 @@ using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using NSubstitute;
 using NUnit.VisualStudio.TestAdapter.Tests.Fakes;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
@@ -55,10 +56,12 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 
         public static IReadOnlyCollection<TestCase> ConvertTestCases(string xml)
         {
+            var settings = Substitute.For<IAdapterSettings>();
+            settings.CollectSourceInformation.Returns(false);
             using (var testConverter = new TestConverter(
                 new TestLogger(new MessageLoggerStub()),
                 FakeTestData.AssemblyPath,
-                collectSourceInformation: false))
+                settings))
             {
                 return testConverter.ConvertTestCases(xml);
             }

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Xml;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
@@ -43,7 +44,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         public void SetUp()
         {
             fakeTestNode = FakeTestData.GetTestNode();
-            testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath, collectSourceInformation: true);
+            var settings = Substitute.For<IAdapterSettings>();
+            settings.CollectSourceInformation.Returns(true);
+            testConverter = new TestConverter(new TestLogger(new MessageLoggerStub()), FakeTestData.AssemblyPath, settings);
         }
 
         [TearDown]

--- a/src/NUnitTestAdapterTests/TraitsTests.cs
+++ b/src/NUnitTestAdapterTests/TraitsTests.cs
@@ -382,8 +382,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             adaptersettings.Verbosity.Returns(5);
             var testlogger = new TestLogger(messagelogger);
             testlogger.InitSettings(adaptersettings);
-
-            testconverter = new TestConverter(testlogger, "whatever", false);
+            var settings = Substitute.For<IAdapterSettings>();
+            settings.CollectSourceInformation.Returns(false);
+            testconverter = new TestConverter(testlogger, "whatever", settings);
             testcaselist = new List<TestCase>();
         }
 
@@ -538,10 +539,12 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 
         private static IReadOnlyList<TestCase> GetTestCases(string xml)
         {
+            var settings = Substitute.For<IAdapterSettings>();
+            settings.CollectSourceInformation.Returns(false);
             using (var converter = new TestConverter(
                 new TestLogger(new MessageLoggerStub()),
                 sourceAssembly: "unused",
-                collectSourceInformation: false))
+                settings))
             {
                 return converter.ConvertTestCases(xml);
             }

--- a/src/NUnitTestAdapterTests/VsExperimentalTests.cs
+++ b/src/NUnitTestAdapterTests/VsExperimentalTests.cs
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
@@ -48,7 +49,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 CodeFilePath = null,
                 LineNumber = 0
             };
-            var cl = new CategoryList(testCase);
+            var settings = Substitute.For<IAdapterSettings>();
+            settings.VsTestCategoryType.Returns(VsTestCategoryType.NUnit);
+            var cl = new CategoryList(testCase,settings);
             cl.AddRange(new List<string> {"one","one","two","two"});
             cl.UpdateCategoriesToVs();
 


### PR DESCRIPTION
Fix for issue #559  and #561 Added option to switch between NUnit  MSTest category types. Defaulting to MSTest to ensure #506 is still working.