### PR TITLE
Use pre-installed NuGet cache to speed up creation of isolated packagee cache for acceptance tests

### DIFF
--- a/tests/nuget.config
+++ b/tests/nuget.config
@@ -5,5 +5,6 @@
   </config>
   <packageSources>
     <add key="Build script package output" value="..\package" />
+    <add key="Pre-downloaded packages" value="C:\Program Files\dotnet\sdk\NuGetFallbackFolder" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This makes the list of packages race by after a `git clean` instead of taking a couple of minutes, on my machine. CI might be faster too.