### PR TITLE
Issue302 native execution

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -299,6 +299,15 @@ namespace NUnit.VisualStudio.TestAdapter
                 // we skip the native c++ binaries that we don't support.
                 TestLog.Warning("   Assembly not supported: " + assemblyPath);
             }
+            catch( NUnitEngineException e )
+            {
+                if( e.InnerException is BadImageFormatException )
+                {
+                    // we skip the native c++ binaries that we don't support.
+                    TestLog.Warning( "   Assembly not supported: " + assemblyPath );
+                }
+                throw;
+            }
             catch (FileNotFoundException ex)
             {
                 // Probably from the GetExportedTypes in NUnit.core, attempting to find an assembly, not a problem if it is not NUnit here


### PR DESCRIPTION
Merge request !369 only fixes #302 for test discovery, not for test execution. There you still get an error when a native binary is given to NUnit, because the BadFormatException is wrapped in a NUnitEngineException and that case was not checked in the execution code path.

Added a test to detect this and a fix for the problem.