### PR TITLE
Add netcoreapp2.0 target framework

### DIFF
--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -36,6 +36,17 @@
             <dependency id="System.Xml.XmlDocument" version="4.3.0" />
             <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" />
         </group>
+        <group targetFramework="netcoreapp2.0">
+            <dependency id="Microsoft.DotNet.InternalAbstractions" version="1.0.0" />
+            <dependency id="System.ComponentModel.EventBasedAsync" version="4.3.0" />
+            <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" />
+            <dependency id="System.Diagnostics.Process" version="4.3.0" />
+            <dependency id="System.Reflection" version="4.3.0" />
+            <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+            <dependency id="System.Threading.Thread" version="4.3.0" />
+            <dependency id="System.Xml.XmlDocument" version="4.3.0" />
+            <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" />
+        </group>
         </dependencies>
     </metadata>
     <files>
@@ -51,6 +62,12 @@
         <file src="build\netcoreapp1.0\nunit.engine.dll" target="build\netcoreapp1.0\nunit.engine.dll" />
         <file src="build\netcoreapp1.0\nunit.engine.api.dll" target="build\netcoreapp1.0\nunit.engine.api.dll" />
         <file src="build\netcoreapp1.0\NUnit3TestAdapter.props" target="build\netcoreapp1.0\NUnit3TestAdapter.props" />
+
+        <file src="build\netcoreapp2.0\NUnit3.TestAdapter.dll" target="build\netcoreapp2.0\NUnit3.TestAdapter.dll" />
+        <file src="build\netcoreapp2.0\NUnit3.TestAdapter.pdb" target="build\netcoreapp2.0\NUnit3.TestAdapter.pdb" />
+        <file src="build\netcoreapp2.0\nunit.engine.dll" target="build\netcoreapp2.0\nunit.engine.dll" />
+        <file src="build\netcoreapp2.0\nunit.engine.api.dll" target="build\netcoreapp2.0\nunit.engine.api.dll" />
+        <file src="build\netcoreapp2.0\NUnit3TestAdapter.props" target="build\netcoreapp2.0\NUnit3TestAdapter.props" />
 
     </files>
 </package>

--- a/nuget/netcoreapp2.0/NUnit3TestAdapter.props
+++ b/nuget/netcoreapp2.0/NUnit3TestAdapter.props
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.dll">
+      <Link>NUnit3.TestAdapter.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb" Condition="Exists('$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb')">
+      <Link>NUnit3.TestAdapter.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </Content>
+      <Content Include="$(MSBuildThisFileDirectory)nunit.engine.dll">
+          <Link>nunit.engine.dll</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Visible>False</Visible>
+      </Content>
+      <Content Include="$(MSBuildThisFileDirectory)nunit.engine.api.dll">
+          <Link>nunit.engine.api.dll</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Visible>False</Visible>
+      </Content>
+  </ItemGroup>
+</Project>

--- a/src/NUnit.TestAdapter.Tests.Acceptance/BundledDependencyTests.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/BundledDependencyTests.cs
@@ -39,7 +39,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance
                         public static void User_tests_get_the_version_of_Mono_Cecil_referenced_from_the_test_project()
                         {
                             var assembly = typeof(Mono.Cecil.ReaderParameters)
-                    #if NETCOREAPP1_0
+                    #if !NET35
                                 .GetTypeInfo()
                     #endif
                                 .Assembly;
@@ -99,7 +99,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance
                         public void Engine_uses_its_bundled_version_of_Mono_Cecil_instead_of_the_version_referenced_by_the_test_project()
                         {
                             var assembly = typeof(Mono.Cecil.ReaderParameters)
-                    #if NETCOREAPP1_0
+                    #if !NET35
                                 .GetTypeInfo()
                     #endif
                                 .Assembly;

--- a/src/NUnitTestAdapter/DumpXml.cs
+++ b/src/NUnitTestAdapter/DumpXml.cs
@@ -114,7 +114,7 @@ namespace NUnit.VisualStudio.TestAdapter.Dump
 
     }
 
-#if !NETCOREAPP1_0
+#if NET35
     public static class XmlNodeExtension
     {
         public static string AsString(this System.Xml.XmlNode node)

--- a/src/NUnitTestAdapter/EmbeddedAssemblyResolution.cs
+++ b/src/NUnitTestAdapter/EmbeddedAssemblyResolution.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
-#if NETCOREAPP1_0
+#if !NET35
 using System.Runtime.Loader;
 #endif
 
@@ -63,7 +63,7 @@ namespace NUnit.VisualStudio.TestAdapter
             if (properCasing == null) return null;
 
             return typeof(EmbeddedAssemblyResolution)
-#if NETCOREAPP1_0
+#if !NET35
                 .GetTypeInfo()
 #endif
                 .Assembly.GetManifestResourceStream(@"Assemblies\" + properCasing + ".dll");

--- a/src/NUnitTestAdapter/Internal/StackframeParser.cs
+++ b/src/NUnitTestAdapter/Internal/StackframeParser.cs
@@ -23,7 +23,7 @@ namespace NUnit.VisualStudio.TestAdapter.Internal
 			string wordAt = null;
 			string wordsInLine = null;
 
-#if !NETCOREAPP1_0
+#if NET35
             // TODO: This doesn't work cross platform
             MethodInfo info = typeof(Environment).GetMethod("GetResourceString", BindingFlags.NonPublic | BindingFlags.Static, null, new[] { typeof(string) }, null);
             if (info != null)

--- a/src/NUnitTestAdapter/Metadata/AppDomainMetadataProvider.cs
+++ b/src/NUnitTestAdapter/Metadata/AppDomainMetadataProvider.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_0
+#if NET35
 using System;
 
 namespace NUnit.VisualStudio.TestAdapter.Metadata

--- a/src/NUnitTestAdapter/Metadata/DirectReflectionMetadataProvider.cs
+++ b/src/NUnitTestAdapter/Metadata/DirectReflectionMetadataProvider.cs
@@ -27,7 +27,7 @@ using System.Linq;
 using System.Reflection;
 using NUnit.VisualStudio.TestAdapter.Internal;
 
-#if NETCOREAPP1_0
+#if !NET35
 using System.Runtime.Loader;
 #endif
 
@@ -87,7 +87,7 @@ namespace NUnit.VisualStudio.TestAdapter.Metadata
         {
             try
             {
-#if NETCOREAPP1_0
+#if !NET35
                 var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
 #else
                 var assembly = Assembly.LoadFrom(assemblyPath);

--- a/src/NUnitTestAdapter/Metadata/TypeInfo.cs
+++ b/src/NUnitTestAdapter/Metadata/TypeInfo.cs
@@ -27,7 +27,7 @@ using NUnit.VisualStudio.TestAdapter.Internal;
 
 namespace NUnit.VisualStudio.TestAdapter.Metadata
 {
-#if !NETCOREAPP1_0
+#if NET35
     [Serializable]
 #endif
     public struct TypeInfo

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>NUnit3.TestAdapter</AssemblyName>
     <RootNamespace>NUnit.VisualStudio.TestAdapter</RootNamespace>
     <!--<TargetFramework>net35</TargetFramework>--><!-- For testing and debugging-->
-    <TargetFrameworks>net35;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\..\Osiris.Extended.ruleset</CodeAnalysisRuleSet>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SourceLinkOriginUrl>https://github.com/nunit/nunit3-vs-adapter</SourceLinkOriginUrl>
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" PrivateAssets="All" />

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -37,7 +37,7 @@ using NUnit.VisualStudio.TestAdapter.Dump;
 
 namespace NUnit.VisualStudio.TestAdapter
 {
-#if NETCOREAPP1_0
+#if !NET35
     [FileExtension(".appx")]
 #endif
     [FileExtension(".dll")]
@@ -94,7 +94,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     runner = GetRunnerFor(sourceAssemblyPath);
 
                     XmlNode topNode = runner.Explore(TestFilter.Empty);
-#if !NETCOREAPP1_0
+#if NET35
                     dumpXml?.AddString(topNode.AsString());
 #endif
                     // Currently, this will always be the case but it might change
@@ -172,7 +172,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 }
                 finally
                 {
-#if !NETCOREAPP1_0
+#if NET35
                     dumpXml?.Dump4Discovery();
 #endif
                     if (runner != null)

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -233,7 +233,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 _activeRunner = GetRunnerFor(assemblyPath);
                 CreateTestOutputFolder();
                 var loadResult = _activeRunner.Explore(TestFilter.Empty);
-#if !NETCOREAPP1_0
+#if NET35
                 dumpXml?.AddString(loadResult.AsString());
 #endif
                 if (loadResult.Name == "test-run")
@@ -322,7 +322,7 @@ namespace NUnit.VisualStudio.TestAdapter
             }
             finally
             {
-#if !NETCOREAPP1_0
+#if NET35
                 dumpXml?.Dump4Execution();
 #endif
                 try
@@ -347,7 +347,7 @@ namespace NUnit.VisualStudio.TestAdapter
                 return;
 
             var path = Path.Combine(TestOutputXmlFolder, $"{Path.GetFileNameWithoutExtension(assemblyPath)}.xml");
-#if !NETCOREAPP1_0
+#if NET35
             var resultService = TestEngine.Services.GetService<IResultService>();
 #else
             var resultService = new ResultService();
@@ -362,7 +362,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         private NUnitTestFilterBuilder CreateTestFilterBuilder()
         {
-#if NETCOREAPP1_0
+#if !NET35
             return new NUnitTestFilterBuilder(new TestFilterService());
 #else
             return new NUnitTestFilterBuilder(TestEngine.Services.GetService<ITestFilterService>());

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -25,7 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if !NETCOREAPP1_0
+#if NET35
 using System.Runtime.Remoting;
 #endif
 using System.Xml;
@@ -43,7 +43,7 @@ namespace NUnit.VisualStudio.TestAdapter
     /// translates each event into a message for the VS test platform.
     /// </summary>
     public class NUnitEventListener :
-#if !NETCOREAPP1_0
+#if NET35
         MarshalByRefObject, 
 #endif
         ITestEventListener, IDisposable // Public for testing
@@ -53,7 +53,7 @@ namespace NUnit.VisualStudio.TestAdapter
         private readonly ITestConverter _testConverter;
         private readonly Dictionary<string, ICollection<XmlNode>> _outputNodes = new Dictionary<string, ICollection<XmlNode>>();
 
-#if !NETCOREAPP1_0
+#if NET35
         public override object InitializeLifetimeService()
         {
             // Give the listener an infinite lease lifetime by returning null
@@ -76,7 +76,7 @@ namespace NUnit.VisualStudio.TestAdapter
         public void OnTestEvent(string report)
         {
             var node = XmlHelper.CreateXmlNode(report);
-#if !NETCOREAPP1_0
+#if NET35
             dumpXml?.AddTestEvent(node.AsString());
 #endif
             try
@@ -124,7 +124,7 @@ namespace NUnit.VisualStudio.TestAdapter
             {
                 if (disposing)
                 {
-#if !NETCOREAPP1_0
+#if NET35
                     RemotingServices.Disconnect(this);
 #endif
                 }

--- a/src/NUnitTestAdapter/NUnitTestAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitTestAdapter.cs
@@ -33,7 +33,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-#if !NETCOREAPP1_0
+#if NET35
 using System.Runtime.Remoting.Channels;
 #endif
 using System.Text;
@@ -65,7 +65,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         protected NUnitTestAdapter()
         {
-#if NETCOREAPP1_0
+#if !NET35
             AdapterVersion = typeof(NUnitTestAdapter).GetTypeInfo().Assembly.GetName().Version.ToString();
 #else
             AdapterVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
@@ -249,7 +249,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         protected static void CleanUpRegisteredChannels()
         {
-#if !NETCOREAPP1_0
+#if NET35
             foreach (IChannel chan in ChannelServices.RegisteredChannels)
                 ChannelServices.UnregisterChannel(chan);
 #endif

--- a/src/NUnitTestAdapter/NavigationDataProvider.cs
+++ b/src/NUnitTestAdapter/NavigationDataProvider.cs
@@ -38,7 +38,7 @@ namespace NUnit.VisualStudio.TestAdapter
         private bool _disableMetadataLookup;
 
         public NavigationDataProvider(string assemblyPath, ITestLogger logger)
-#if NETCOREAPP1_0
+#if !NET35
             : this(assemblyPath, logger, new DirectReflectionMetadataProvider())
 #else
             : this(assemblyPath, logger, CreateMetadataProvider(assemblyPath))

--- a/src/NUnitTestAdapter/Registry.cs
+++ b/src/NUnitTestAdapter/Registry.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_0
+﻿#if NET35
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <RootNamespace>NUnit.VisualStudio.TestAdapter.Tests</RootNamespace>
     <AssemblyName>NUnit.VisualStudio.TestAdapter.Tests</AssemblyName>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <!--<TargetFrameworks>net46</TargetFrameworks>-->     <!-- For testing and debugging-->
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' or '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
   </ItemGroup>

--- a/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-#if !NETCOREAPP1_0
+#if NET35
 using System.Runtime.Remoting;
 #endif
 using System.Xml;
@@ -150,7 +150,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         #endregion
 
         #region Listener Lifetime Tests
-#if !NETCOREAPP1_0
+#if NET35
         [Test]
         public void Listener_LeaseLifetimeWillNotExpire()
         {

--- a/src/NUnitTestAdapterTests/ProjectTests.cs
+++ b/src/NUnitTestAdapterTests/ProjectTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
     [TestFixture]
     public class ProjectTests
     {
-#if !NETCOREAPP1_0
+#if NET35
         [Test]
         public void ThatTheReferenceToMicrosoftTestObjectModelPointsToVS2012Version()
         {

--- a/src/NUnitTestAdapterTests/RegistryTests.cs
+++ b/src/NUnitTestAdapterTests/RegistryTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_0
+﻿#if NET35
 using Microsoft.Win32;
 using NUnit.Framework;
 

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -287,7 +287,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 .ToList();
             Summary = new ResultSummary(testResults);
         }
-#if !NETCOREAPP1_0
+#if NET35
         [Test]
         public void ThatTestOutputXmlHasBeenCreatedBelowAssemblyFolder()
         {


### PR DESCRIPTION
Just added `netcoreapp2.0` target framework which uses `netstandard2.0` nunit.engine dependency. New engine 3.10 has extensibility feature which is available only in `netstandard2.0`.

- Changed preprocessor directives to `NET35` or '!NET35' to identify whether it's netcoreapp or not
- Adopted tests
- Adjusted nuget package

@OsirisTerje please review.