### PR TITLE
Assert.Multiple produces new tests in the report if inner assertions fail

### DIFF
--- a/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEventListenerTests.cs
@@ -194,7 +194,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 
             Assert.AreEqual(Environment.MachineName, ourResult.ComputerName);
             Assert.AreEqual(TestOutcome.Passed, ourResult.Outcome);
-            Assert.AreEqual("It passed!", ourResult.ErrorMessage);
+            Assert.AreEqual(null, ourResult.ErrorMessage);
             Assert.AreEqual(TimeSpan.FromSeconds(1.234), ourResult.Duration);
         }
 

--- a/src/NUnitTestAdapterTests/TestConverterTests.cs
+++ b/src/NUnitTestAdapterTests/TestConverterTests.cs
@@ -146,7 +146,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             CheckTestCase(testCase);
 
             Assert.That(testResult.Outcome, Is.EqualTo(TestOutcome.Passed));
-            Assert.That(testResult.ErrorMessage, Is.EqualTo("It passed!"));
+            Assert.That(testResult.ErrorMessage, Is.EqualTo(null));
             Assert.That(testResult.Duration, Is.EqualTo(TimeSpan.FromSeconds(1.234)));
         }
 

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -157,7 +157,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 .Count(e => e.EventType == FakeFrameworkHandle.EventType.RecordResult && e.TestResult.Outcome == outcome);
         }
 
-        [TestCase("MockTest3", TestOutcome.Passed, "Succeeded!", false)]
+        [TestCase("MockTest3", TestOutcome.Passed, null, false)]
         [TestCase("FailingTest", TestOutcome.Failed, "Intentional failure", true)]
         [TestCase("TestWithException", TestOutcome.Failed, "System.Exception : Intentional Exception", true)]
         // NOTE: Should Inconclusive be reported as TestOutcome.None?
@@ -174,7 +174,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(testResult.Outcome, Is.EqualTo(outcome));
             Assert.That(testResult.ErrorMessage, Is.EqualTo(message));
             if (hasStackTrace)
-                Assert.NotNull(testResult.ErrorStackTrace);
+                Assert.NotNull(testResult.ErrorStackTrace, "Unable to find error stacktrace");
         }
 
         [Test]
@@ -202,30 +202,30 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             var fakeFramework = new FakeFrameworkHandle();
 
             // Find the native exaple dll.
-            var path = Path.Combine( TestContext.CurrentContext.TestDirectory, "NativeTests.dll" );
-            Assert.That( File.Exists( path ) );
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "NativeTests.dll");
+            Assert.That(File.Exists(path));
 
             // Try to execute tests from the dll.
             TestAdapterUtils.CreateExecutor().RunTests(
                 new[] { path },
                 context,
-                fakeFramework );
+                fakeFramework);
 
             // Gather results.
             var testResults = fakeFramework.Events
-               .Where( e => e.EventType == FakeFrameworkHandle.EventType.RecordResult )
-               .Select( e => e.TestResult )
+               .Where(e => e.EventType == FakeFrameworkHandle.EventType.RecordResult)
+               .Select(e => e.TestResult)
                .ToList();
 
             // No tests found.
-            Assert.That( testResults.Count, Is.EqualTo( 0 ) );
+            Assert.That(testResults.Count, Is.EqualTo(0));
 
             // A warning about unsupported assebly format provided.
             var messages = fakeFramework.Events
-                .Where( e=> e.EventType == FakeFrameworkHandle.EventType.SendMessage &&
-                    e.Message.Level == Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging.TestMessageLevel.Warning )
-                .Select( o => o.Message.Text );
-            Assert.That( messages, Has.Some.Contains( "Assembly not supported" ) );
+                .Where(e => e.EventType == FakeFrameworkHandle.EventType.SendMessage &&
+                   e.Message.Level == Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging.TestMessageLevel.Warning)
+                .Select(o => o.Message.Text);
+            Assert.That(messages, Has.Some.Contains("Assembly not supported"));
         }
 #endif
 
@@ -250,8 +250,6 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                             .Select(e => e.TestResult)
                             .FirstOrDefault();
         }
-
-
     }
 
 


### PR DESCRIPTION
This PR fixes #630 (Assert.Multiple produces new tests in the report if inner assertions fail).

Changes:
- Reworked parsing`test-case` xml node to not consider `assertions` node
- Don't set `ErrorMessage` property for passed tests