### PR TITLE
Fix Azure Pipelines CI build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -100,22 +100,10 @@ Task("Clean")
 });
 
 //////////////////////////////////////////////////////////////////////
-// INITIALIZE FOR BUILD
-//////////////////////////////////////////////////////////////////////
-
-Task("NuGetRestore")
-    .Does(() =>
-{
-    Information("Restoring NuGet Packages for the Adapter Solution");
-    DotNetCoreRestore(ADAPTER_SOLUTION);
-});
-
-//////////////////////////////////////////////////////////////////////
 // BUILD
 //////////////////////////////////////////////////////////////////////
 
 Task("Build")
-    .IsDependentOn("NuGetRestore")
     .Does(() =>
     {
         // Find MSBuild for Visual Studio 2019 and newer
@@ -143,7 +131,8 @@ Task("Build")
             {
                 ["PackageVersion"] = packageVersion
             },
-            Verbosity = Verbosity.Minimal
+            Verbosity = Verbosity.Minimal,
+            Restore = true
         });
     });
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.1.100",
+    "version": "2.1.700",
     "rollForward": "feature"
   }
 }


### PR DESCRIPTION
Fixes 'NUnit3TestAdapter.Github.Cake.CI' which I broke in https://github.com/nunit/nunit3-vs-adapter/pull/663.

(You generally can't go wrong by betting on `msbuild /t:Build /restore` rather than a separate `nuget restore` or `dotnet restore` phase.)