### PR TITLE
Resolve issue with custom tests names and test Ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,5 @@ tools/
 # VisualStudioCode Patch
 # Ignore all local history of files
 .history
+/Dump
+/src/NUnitTestAdapterTests/Dump

--- a/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
@@ -1,0 +1,130 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance
+{
+    public sealed class TestSourceWithCustomNames : AcceptanceTests
+    {
+        private static void AddTestsCs(IsolatedWorkspace workspace)
+        {
+            workspace.AddFile("Tests.cs", @"
+                using System;
+                using System.Collections;
+                using System.Collections.Generic;
+                using NUnit.Framework;
+
+                namespace Test
+                {
+                    public class Tests
+                    {
+                        [Test]
+                        [TestCaseSource(nameof(TestCaseSourceMethod))]
+                        public void PassingTestStr(object arg)
+                        {
+                            Assert.Pass();
+                        }
+
+
+                        private static IEnumerable<TestCaseData> TestCaseSourceMethod()
+                        {
+                            yield return new TestCaseData(""Name with mismatched parenthesis 'pp:-) :-)'"").SetName(""Name with mismatched parenthesis 'pp:-) :-)'"");
+                            yield return new TestCaseData(""Name with mismatched quote '\""c'"").SetName(""Name with mismatched quote '\""c'"");
+                            
+                            // Adding a parenthesis to the end of this test name will stop the exception from throwing (e.g. $""TestName(...)"")
+                            yield return new TestCaseData(1).SetName($""TestName(..."");
+
+                            // Cannot be duplicated without a second test included that ends with a ']'
+                            yield return new TestCaseData(2).SetName($""TestName(...)]"");
+                        }
+
+                        [Test]
+                        [TestCase(typeof(IEnumerable<(String oneValue, Int32 twoValue)>))]
+                        public void UnitTest_TestCaseWithTuple_TestIsNotExecuted(Type targetType)
+                        {
+                            Assert.That(targetType == typeof(IEnumerable<(String oneValue, Int32 twoValue)>), Is.True);
+                        }
+
+                        [Test, TestCaseSource(nameof(SourceA))]
+                        public void TestA((int a, int b) x, int y) { }
+                        public static IEnumerable SourceA => new[] {new TestCaseData((a: 1, b: 2), 5)};
+
+                        [Test, TestCaseSource(nameof(SourceB))]
+                        public void TestB(int y, (int a, int b) x) { }
+                        public static IEnumerable SourceB => new[] {new TestCaseData(5, (a: 1, b: 2))};
+
+                        [Test, TestCaseSource(nameof(SourceC))]
+                        public void TestC((int a, int b) x, int y) { }
+                        public static IEnumerable SourceC => new[] {new TestCaseData((a: 1, b: 2), 5).SetArgDisplayNames(""a+b"", ""y"")};
+
+                        [Test(), TestCaseSource(typeof(CaseTestData), nameof(CaseTestData.EqualsData))]
+                        public void EqualsTest(Case case1, Case case2)
+                        {
+                            Assert.AreEqual(case1, case2);
+                        }
+
+                        public class CaseTestData
+                        {
+                            public static IEnumerable EqualsData()
+                            {
+                                yield return new object[] { new Case { Name = ""case1"" }, new Case { Name = ""case1"" } };
+                            }
+                        }
+
+                        public class Case
+                        {
+                            public string Name;
+                            public override string ToString() => Name;
+                            public override bool Equals(object obj) => obj is Case other && other.Name == this.Name;
+                        }
+
+                    }
+                }");
+        }
+
+        [Test]
+        [TestCase("net47")] //test code requires ValueTuple support, so can't got to net35
+        [TestCase("netcoreapp2.1")]
+        public static void Single_target_csproj(string targetFramework)
+        {
+            var workspace = CreateWorkspace()
+                .AddProject("Test.csproj", $@"
+                    <Project Sdk='Microsoft.NET.Sdk'>
+
+                      <PropertyGroup>
+                        <TargetFramework>{targetFramework}</TargetFramework>
+                      </PropertyGroup>
+
+                      <ItemGroup>
+                        <PackageReference Include='Microsoft.NET.Test.Sdk' Version='*' />
+                        <PackageReference Include='NUnit' Version='*' />
+                        <PackageReference Include='NUnit3TestAdapter' Version='{NuGetPackageVersion}' />
+                      </ItemGroup>
+
+                    </Project>");
+
+            AddTestsCs(workspace);
+
+            workspace.MSBuild(restore: true);
+
+            var results = workspace.VSTest(new[] { $@"bin\Debug\{targetFramework}\Test.dll" });
+
+            //Total Tests =
+            //              3 from PassingTestStr/TestCaseSourceMethod
+            //              1 from UnitTest_TestCaseWithTuple_TestIsNotExecuted
+            //              1 from TestA/SourceA
+            //              1 from TestB/SourceB
+            //              1 from TestC/SourceC
+            //              2 from EqualsTest/EqualsData
+            //-------------------
+            //              9 Total Tests
+
+
+
+            Assert.That(results.Counters.Total, Is.EqualTo(9), "Total tests counter did not match expectation" );
+            Assert.That(results.Counters.Executed, Is.EqualTo(9), "Executed tests counter did not match expectation");
+            Assert.That(results.Counters.Passed, Is.EqualTo(9), "Passed tests counter did not match expectation");
+        }
+
+    }
+}

--- a/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
@@ -39,10 +39,10 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance
                         }
 
                         [Test]
-                        [TestCase(typeof(IEnumerable<(String oneValue, Int32 twoValue)>))]
+                        [TestCase(typeof(IEnumerable<(string oneValue, int twoValue)>))]
                         public void UnitTest_TestCaseWithTuple_TestIsNotExecuted(Type targetType)
                         {
-                            Assert.That(targetType == typeof(IEnumerable<(String oneValue, Int32 twoValue)>), Is.True);
+                            Assert.That(targetType, Is.TypeOf(typeof(IEnumerable<(string oneValue, int twoValue)>)));
                         }
 
                         [Test, TestCaseSource(nameof(SourceA))]

--- a/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
@@ -42,7 +42,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance
                         [TestCase(typeof(IEnumerable<(string oneValue, int twoValue)>))]
                         public void UnitTest_TestCaseWithTuple_TestIsNotExecuted(Type targetType)
                         {
-                            Assert.That(targetType, Is.TypeOf(typeof(IEnumerable<(string oneValue, int twoValue)>)));
+                            Assert.That(targetType, Is.EqualTo(typeof(IEnumerable<(string oneValue, int twoValue)>)));
                         }
 
                         [Test, TestCaseSource(nameof(SourceA))]

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -160,22 +160,38 @@ namespace NUnit.VisualStudio.TestAdapter
         /// </summary>
         private TestCase MakeTestCaseFromXmlNode(XmlNode testNode)
         {
+            var fullyQualifiedName = testNode.GetAttribute("fullname");
+            var parentType = testNode.ParentNode.GetAttribute("type");
+            if (parentType == "ParameterizedMethod")
+            {
+                var parameterizedTestFullName = testNode.ParentNode.GetAttribute("fullname");
 
-            var className = testNode.GetAttribute("classname");
-            var methodName = testNode.GetAttribute("methodname");
-           
-            // VS expected FullName to be the actual class+type name,optionally with parameter types
-            // in parenthesis, but they must fit the pattern of a value returned by object.GetType().
-            // It should _not_ include custom name or param values (just their types).
-            // However, the "fullname" from NUnit's file generation is the custom name of the test, so
-            // this code must convert from one to the other.
-            // Reference: https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md
-            var fullname = className + "." + methodName;
+                // VS expected FullyQualifiedName to be the actual class+type name,optionally with parameter types
+                // in parenthesis, but they must fit the pattern of a value returned by object.GetType().
+                // It should _not_ include custom name or param values (just their types).
+                // However, the "fullname" from NUnit's file generation is the custom name of the test, so
+                // this code must convert from one to the other.
+                // Reference: https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md
+
+                // Using the nUnit-provided "fullname" will cause failures at test execution time due to
+                // the FilterExpressionWrapper not being able to parse the test names passed-in as filters.
+
+                // To resolve this issue, for parameterized tests (which are the only tests that allow custom names),
+                // the parent node's "fullname" value is used instead. This is the name of the actual test method
+                // and will allow the filtering to work as expected.
+
+                if (!string.IsNullOrEmpty(parameterizedTestFullName))
+                {
+                    fullyQualifiedName = parameterizedTestFullName;
+                }
+
+            }
+        
 
             var id = testNode.GetAttribute("id");
 
             var testCase = new TestCase(
-                                    fullname,
+                                    fullyQualifiedName,
                                      new Uri(NUnitTestAdapter.ExecutorUri),
                                      _sourceAssembly)
             {
@@ -187,6 +203,9 @@ namespace NUnit.VisualStudio.TestAdapter
 
             if (CollectSourceInformation && _navigationDataProvider != null)
             {
+                var className = testNode.GetAttribute("classname");
+                var methodName = testNode.GetAttribute("methodname");
+
                 var navData = _navigationDataProvider.GetNavigationData(className, methodName);
                 if (navData.IsValid)
                 {

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using VSTestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 namespace NUnit.VisualStudio.TestAdapter
@@ -159,20 +160,33 @@ namespace NUnit.VisualStudio.TestAdapter
         /// </summary>
         private TestCase MakeTestCaseFromXmlNode(XmlNode testNode)
         {
+
+            var className = testNode.GetAttribute("classname");
+            var methodName = testNode.GetAttribute("methodname");
+           
+            // VS expected FullName to be the actual class+type name,optionally with parameter types
+            // in parenthesis, but they must fit the pattern of a value returned by object.GetType().
+            // It should _not_ include custom name or param values (just their types).
+            // However, the "fullname" from NUnit's file generation is the custom name of the test, so
+            // this code must convert from one to the other.
+            // Reference: https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md
+            var fullname = className + "." + methodName;
+
+            var id = testNode.GetAttribute("id");
+
             var testCase = new TestCase(
-                                     testNode.GetAttribute("fullname"),
+                                    fullname,
                                      new Uri(NUnitTestAdapter.ExecutorUri),
                                      _sourceAssembly)
             {
                 DisplayName = testNode.GetAttribute("name"),
                 CodeFilePath = null,
-                LineNumber = 0
+                LineNumber = 0,
+                Id = EqtHash.GuidFromString(id)
             };
 
             if (CollectSourceInformation && _navigationDataProvider != null)
             {
-                var className = testNode.GetAttribute("classname");
-                var methodName = testNode.GetAttribute("methodname");
                 var navData = _navigationDataProvider.GetNavigationData(className, methodName);
                 if (navData.IsValid)
                 {

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -87,7 +87,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [TestCase("MockTest3", "NUnit.Tests.Assemblies.MockTestFixture.MockTest3")]
         [TestCase("MockTest4", "NUnit.Tests.Assemblies.MockTestFixture.MockTest4")]
         [TestCase("ExplicitlyRunTest", "NUnit.Tests.Assemblies.MockTestFixture.ExplicitlyRunTest")]
-        [TestCase("MethodWithParameters(9,11)", "NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)")]
+        [TestCase("MethodWithParameters(9,11)", "NUnit.Tests.FixtureWithTestCases.MethodWithParameters")]
         public void VerifyTestCaseIsFound(string name, string fullName)
         {
             var testCase = testCases.Find(tc => tc.DisplayName == name);


### PR DESCRIPTION
This PR is to address #622 

Key highlights:

- The FullyQualifiedName is based on Type+Method and independent of DisplayName.
- The TestCaseId is unique across all test cases (including data-driven ones) and deterministic between discovery sessions.

## Background information:
- The VS test system [expects the `TestCase.FullyQualifiedName` to be the actual test method name](https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#specification) (not the display name), optionally including param _types_ (not values). Basically, the details that would have been returned from `caller.GetType().FullName`
- If you don't provide a value for `TestCase.Id`, the class with [create a GUID](https://github.com/microsoft/vstest/blob/829659f9ca95ccfb54480948d8e472651dd0ff5d/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs#L96) value [based on the `TestCase.FullyQualifiedName`](https://github.com/microsoft/vstest/blob/829659f9ca95ccfb54480948d8e472651dd0ff5d/src/Microsoft.TestPlatform.ObjectModel/TestCase.cs#L240). 
- When running tests, if you instruct the system to run a subset of tests (ie: not "all" tests), a filter is provided by VS that includes a list of tests by `FullyQualifiiedName`, which the NUnitAdapter attempt to apply in `TfsTestFilter.CheckFilter(TestCase)`.
- The test hierarchy in the VS Test Explorer UI uses the `FullyQualifiedName` to determine the namespace groupings
- If multiple tests results are associated with the same TestCase instance (ie: `TestCase.Id` is equal), then [it will show the test once in the UI, with multiple result values](https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#tests-returning-multiple-results), such as this (which is how MSTest-based tests display results when a method is used for test cases):
![image](https://user-images.githubusercontent.com/3373249/67701209-88a12080-f97d-11e9-8f8c-d271a330c377.png)


## How this issue manifested:
- The [current logic](https://github.com/nunit/nunit3-vs-adapter/blob/e12dcb031828181148397058ab43d07e1db2fcad/src/NUnitTestAdapter/TestConverter.cs#L167) sets the `DisplayName` and `FullyQualifiedName` to the display name of the test, which break the contract with VS if the user has utilized the `SetName()` method to override the display name value.  While VS doesn't strictly enforce the `FullyQualifiedName` is an actual method, it does have [some minor validation](https://github.com/microsoft/vstest/blob/829659f9ca95ccfb54480948d8e472651dd0ff5d/src/Microsoft.TestPlatform.Common/Filtering/FilterExpression.cs#L114) to make sure some special characters are used as expected, such as paired parenthesis, resulting in an error such as:
> An exception occurred while invoking executor 'executor://nunit3testexecutor/': Incorrect format for TestCaseFilter Error: Missing '('. Specify the correct format and try again. Note that the incorrect format can lead to no test getting executed.

## How I addressed the issue:
- First, but setting the `TestCase.FullyQualfiedName` to the actual test method name, this conforms with the expectations from VS and fixes the parsing issues.  Since the NUnit-parsed data includes a `classname` and `methodname` attribute, the FQN can be created from that (or, at least, a close-enough version).
- By using the method type+name for the `FullyQualifiedName`, if the adapter doesn't explicitly set the `TestCast.Id`, it will result in each TestCase having the default Id based on the FQN, as described in the Background Information above. Meaning: When the adapter recreates the TestCase object for association with the TestResult object returned with the test results, it would return several results with the same TestCase.Id value, since each of those would have the same FQN. This resulted in the UI displaying the results under the same Test (similar to the screenshot above).  This does not match the existing behavior, where each test case is listed as it's own node in the test case explorer.  Additionally, only the first DisplayName was shown in the UI, since it ignored tests with identical Ids, due to [Ids needing to be unique](https://github.com/microsoft/vstest-docs/blob/master/RFCs/0017-Managed-TestCase-Properties.md#uniqueness). Since NUnit already applies a unique id to each test, which is consistent across test runs, I decided to resolve this issue by assigning the `TestCase.Id` property using the NUnit id attribute value.  This will give each TestCase a unique Id even if they have the same `FullyQualifiedName`, resulting in the individual nodes that is currently used.


## Impacts of changes
I primarily used two sets of tests while working on this PR.  The first is a test class I put together from the use cases listed in #622, which I put into [this gist](https://gist.github.com/johnmwright/bf374e3ac588fd9ceb8476148578772c) and ultimately added as a unit test in this PR.  The other is the [sample solution](https://github.com/johnjaylward/nUnitExpressionTest) provided in comments to #622 . I'll be using these to describe the impacts of this change.

Before the changes, when the problematic parameterized tests were run, you would see:
- the actual name of the test (example: `Repo_jwright.DemoTest2` in screenshot 1), in addition to the parameterized custom names (ex: `Repo_jwright.Name with mismatched quote '"c'`) as peers.
- Tests which had mismatched special characters were represented as inconclusive (aka "Not Run") at the end of the test run, due to the "Incorrect format for TestCaseFilter" error (ex: `Repo_jwright.DemoTest2` in screenshot 1)
- Parameterized tests were grouped across many nodes when custom names were given (see various nodes for `ExpressionTransatorTest` in screenshot 2)


Screenshot 1:
![image](https://user-images.githubusercontent.com/3373249/67712575-40402d80-f992-11e9-8d64-b701747056db.png)

Screenshot 2:
![image](https://user-images.githubusercontent.com/3373249/67712676-72518f80-f992-11e9-9f03-581a5edc66ba.png)


After the changes:
- The Test name itself is no longer a node with results, but rather it's a grouping node (see: `Repo_jwright.DemoTest2` in screenshot 1)
- Tests which have mismatched special characters no longer throw an error and now show their proper results
- Parameterized tests are grouped under the same node based on the FullyQualifiedTestName value (see screenshot 2)


Screenshot 1:
![image](https://user-images.githubusercontent.com/3373249/67712749-92814e80-f992-11e9-8016-966503a4cf45.png)

![image](https://user-images.githubusercontent.com/3373249/67712967-f1df5e80-f992-11e9-8207-9960159ae93d.png)


## Possible Breaking Change
Because this PR changes how the `TestCase.Id` property is generated, this will result in test cases having different IDs than they did before the change was implemented.  Any systems that expect the test ID value to remain the same across history will lose their tracking of test cases.  

This is specifically called out in the inline comments of [`EqtHash.GuidFromString`](https://github.com/microsoft/vstest/blob/829659f9ca95ccfb54480948d8e472651dd0ff5d/src/Microsoft.TestPlatform.ObjectModel/Utilities/EqtHash.cs#L26) in the VSTest codebase, but with the references between TFS/MsftDevOps Bugs and TFS/MsftDevOps workitems.  I am unsure what, if any, associations TFS/MsftDevOps places with test run results.

