### PR TITLE
Allow specifying Test Selection Language filters in VSTest runsettings

### DIFF
--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -41,6 +41,7 @@ namespace NUnit.VisualStudio.TestAdapter
         IDictionary<string, string> TestProperties { get; }
         string InternalTraceLevel { get; }
         string WorkDirectory { get; }
+        string Where { get; }
         int DefaultTimeout { get; }
         int NumberOfTestWorkers { get; }
         bool ShadowCopyFiles { get; }
@@ -157,6 +158,7 @@ namespace NUnit.VisualStudio.TestAdapter
         public string InternalTraceLevel { get; private set; }
 
         public string WorkDirectory { get; private set; }
+        public string Where { get; private set; }
         public string TestOutputXml { get; private set; }
         public bool UseTestOutputXml => !string.IsNullOrEmpty(TestOutputXml);
         public int DefaultTimeout { get; private set; }
@@ -254,6 +256,7 @@ namespace NUnit.VisualStudio.TestAdapter
             InternalTraceLevel = GetInnerTextWithLog(nunitNode, nameof(InternalTraceLevel), "Off", "Error", "Warning",
                 "Info", "Verbose", "Debug");
             WorkDirectory = GetInnerTextWithLog(nunitNode, nameof(WorkDirectory));
+            Where = GetInnerTextWithLog(nunitNode, nameof(Where));
             DefaultTimeout = GetInnerTextAsInt(nunitNode, nameof(DefaultTimeout), 0);
             NumberOfTestWorkers = GetInnerTextAsInt(nunitNode, nameof(NumberOfTestWorkers), -1);
             ShadowCopyFiles = GetInnerTextAsBool(nunitNode, nameof(ShadowCopyFiles), false);

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -99,8 +99,9 @@ namespace NUnit.VisualStudio.TestAdapter
                 try
                 {
                     var assemblyPath = Path.IsPathRooted(assemblyName) ? assemblyName : Path.Combine(Directory.GetCurrentDirectory(), assemblyName);
+                    var filter = CreateTestFilterBuilder().FilterByWhere(Settings.Where);
 
-                    RunAssembly(assemblyPath, null, TestFilter.Empty);
+                    RunAssembly(assemblyPath, null, filter);
                 }
                 catch (Exception ex)
                 {
@@ -145,7 +146,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     var assemblyPath = Path.IsPathRooted(assemblyName) ? assemblyName : Path.Combine(Directory.GetCurrentDirectory(), assemblyName);
 
                     var filterBuilder = CreateTestFilterBuilder();
-                    var filter = filterBuilder.MakeTestFilter(assemblyGroup);
+                    var filter = filterBuilder.FilterByList(assemblyGroup);
 
                     RunAssembly(assemblyPath, assemblyGroup, filter);
                 }

--- a/src/NUnitTestAdapter/NUnitTestFilterBuilder.cs
+++ b/src/NUnitTestAdapter/NUnitTestFilterBuilder.cs
@@ -26,18 +26,30 @@ namespace NUnit.VisualStudio.TestAdapter
             var filteredTestCases = tfsFilter.CheckFilter(loadedTestCases);
             var testCases = filteredTestCases as TestCase[] ?? filteredTestCases.ToArray();
             //TestLog.Info(string.Format("TFS Filter detected: LoadedTestCases {0}, Filterered Test Cases {1}", loadedTestCases.Count, testCases.Count()));
-            return MakeTestFilter(testCases);
+            return FilterByList(testCases);
         }
 
-        public TestFilter MakeTestFilter(IEnumerable<TestCase> testCases)
+        public TestFilter FilterByWhere(string where)
         {
-            if (testCases.Count() == 0)
-                return NoTestsFound;
+            ITestFilterBuilder filterBuilder = _filterService.GetTestFilterBuilder();
+            
+            if(!string.IsNullOrEmpty(where))
+            {
+                filterBuilder.SelectWhere(where);
+            }
+            
+            return filterBuilder.GetFilter();
 
+        }
+
+        public TestFilter FilterByList(IEnumerable<TestCase> testCases)
+        {
             ITestFilterBuilder filterBuilder = _filterService.GetTestFilterBuilder();
 
             foreach (TestCase testCase in testCases)
+            {
                 filterBuilder.AddTest(testCase.FullyQualifiedName);
+            }
 
             return filterBuilder.GetFilter();
         }

--- a/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
+++ b/src/NUnitTestAdapterTests/AdapterSettingsTests.cs
@@ -367,5 +367,12 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             Assert.That(_settings.NumberOfTestWorkers, Is.Zero);
             Assert.True(_settings.InProcDataCollectorsAvailable);
         }
+        
+        [Test]
+        public void WhereCanBeSet()
+        {
+            _settings.Load("<RunSettings><NUnit><Where>cat == SomeCategory and namespace == SomeNamespace or cat != SomeOtherCategory</Where></NUnit></RunSettings>");
+            Assert.That(_settings.Where, Is.EqualTo("cat == SomeCategory and namespace == SomeNamespace or cat != SomeOtherCategory"));
+        }
     }
 }

--- a/src/NUnitTestAdapterTests/Fakes/FakeRunSettings.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeRunSettings.cs
@@ -54,4 +54,15 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
         public override string SettingsXml => $"<RunSettings><NUnit><WorkDirectory>{_workDir}</WorkDirectory><TestOutputXml>{_testOutput}</TestOutputXml></NUnit></RunSettings>";
     }
 
+    class FakeRunSettingsForWhere : FakeRunSettings
+    {
+        private readonly string _where;
+
+        public FakeRunSettingsForWhere(string where)
+        {
+            _where = where;
+        }
+        public override string SettingsXml => $"<RunSettings><NUnit><Where>{_where}</Where></NUnit></RunSettings>";
+    }
+
 }

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -62,6 +62,48 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
     }
 
 
+    [Category("TestExecution")]
+    public class TestFilteringTests
+    {
+        private string MockAssemblyPath;
+        [OneTimeSetUp]
+        public void LoadMockassembly()
+        {
+            MockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
+
+            // Sanity check to be sure we have the correct version of mock-assembly.dll
+            Assert.That(MockAssembly.TestsAtRuntime, Is.EqualTo(MockAssembly.Tests),
+                "The reference to mock-assembly.dll appears to be the wrong version");
+        }
+
+        [TestCase("", 35)]
+        [TestCase(null, 35)]
+        [TestCase("cat == Special", 1)]
+        [TestCase("cat == MockCategory", 2)]
+        [TestCase("method =~ MockTest?", 5)]
+        [TestCase("method =~ MockTest? and cat != MockCategory", 3)]
+        [TestCase("namespace == ThisNamespaceDoesNotExist", 0)]
+        [TestCase("test==NUnit.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests, TestName = "{m}_MockTestFixture")]
+        [TestCase("test==NUnit.Tests.IgnoredFixture and method == Test2", 1, TestName = "{m}_IgnoredFixture")]
+        [TestCase("class==NUnit.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests)]
+        [TestCase("name==MockTestFixture", MockTestFixture.Tests + NUnit.Tests.TestAssembly.MockTestFixture.Tests)]
+        [TestCase("cat==FixtureCategory", MockTestFixture.Tests)]
+        public void TestsWhereShouldFilter(string filter, int expectedCount)
+        {
+            // Create a fake environment.
+            var context = new FakeRunContext(new FakeRunSettingsForWhere(filter));
+            var fakeFramework = new FakeFrameworkHandle();
+
+            var executor = TestAdapterUtils.CreateExecutor();
+            executor.RunTests(new[] { MockAssemblyPath }, context, fakeFramework);
+
+            var completedRuns = fakeFramework.Events.Where(e => e.EventType == FakeFrameworkHandle.EventType.RecordEnd);
+
+            Assert.That(completedRuns, Has.Exactly(expectedCount).Items);
+
+        }
+
+    }
 
     [Category("TestExecution")]
     public class TestExecutionTests


### PR DESCRIPTION
This allows using `dotnet test` as a drop in replacement for a
nunit-console run with the `--where` option.

i.e.:

`nunit-console SomeTests.dll --where "cat == SomeCategory"`
becomes
`dotnet test SomeTest.csproj -- NUnit.TestsWhere="cat == SomeCategory"`

Related: #425, #655
