### PR TITLE
Include more actionable diagnostic info for acceptance test failures

### DIFF
--- a/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
@@ -83,7 +83,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance
         }
 
         [Test]
-        [TestCase("net47")] //test code requires ValueTuple support, so can't got to net35
+        [TestCase("net48")] //test code requires ValueTuple support, so can't got to net35
         [TestCase("netcoreapp2.1")]
         public static void Single_target_csproj(string targetFramework)
         {

--- a/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessErrorException.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessErrorException.cs
@@ -5,30 +5,30 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
 {
     public sealed class ProcessErrorException : Exception
     {
-        public ProcessErrorException(string processName, int exitCode, string stdOut, string stdErr)
-            : base(BuildMessage(processName, exitCode, stdOut, stdErr))
+        public ProcessErrorException(ProcessRunResult result)
+            : base(BuildMessage(result))
         {
-            ProcessName = processName;
-            ExitCode = exitCode;
-            StdOut = stdOut;
-            StdErr = stdErr;
+            Result = result;
         }
 
-        public string ProcessName { get; }
-        public int ExitCode { get; }
-        public string StdOut { get; }
-        public string StdErr { get; }
+        public ProcessRunResult Result { get; }
 
-        private static string BuildMessage(string processName, int exitCode, string stdOut, string stdErr)
+        private static string BuildMessage(ProcessRunResult result)
         {
             var builder = new StringBuilder();
-            builder.Append("Process ‘").Append(processName);
-            builder.Append("’ exited with code ").Append(exitCode).Append('.');
+            builder.Append("Process ‘").Append(result.ProcessName);
+            builder.Append("’ exited with code ").Append(result.ExitCode).Append('.');
+            builder.AppendLine().Append("Executable: ").Append(result.FileName);
 
-            if (stdErr != null || stdOut != null)
+            if (!string.IsNullOrWhiteSpace(result.Arguments))
             {
-                builder.AppendLine(stdErr != null ? " Stderr:" : " Stdout:");
-                builder.Append(stdErr ?? stdOut);
+                builder.AppendLine().Append("Arguments: ").Append(result.Arguments);
+            }
+
+            if (result.StdErr != null || result.StdOut != null)
+            {
+                builder.AppendLine().Append(result.StdErr != null ? "Stderr:" : "Stdout:");
+                builder.AppendLine().Append(result.StdErr ?? result.StdOut);
             }
 
             return builder.ToString();

--- a/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessErrorException.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessErrorException.cs
@@ -25,10 +25,12 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                 builder.AppendLine().Append("Arguments: ").Append(result.Arguments);
             }
 
-            if (result.StdErr != null || result.StdOut != null)
+            var hasStdErr = !string.IsNullOrWhiteSpace(result.StdErr);
+
+            if (hasStdErr || !string.IsNullOrWhiteSpace(result.StdOut))
             {
-                builder.AppendLine().Append(result.StdErr != null ? "Stderr:" : "Stdout:");
-                builder.AppendLine().Append(result.StdErr ?? result.StdOut);
+                builder.AppendLine().Append(hasStdErr ? "Stderr:" : "Stdout:");
+                builder.AppendLine().Append(hasStdErr ? result.StdErr : result.StdOut);
             }
 
             return builder.ToString();

--- a/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessRunResult.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessRunResult.cs
@@ -5,15 +5,18 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
 {
     public readonly struct ProcessRunResult
     {
-        public ProcessRunResult(string fileName, int exitCode, string stdOut, string stdErr)
+        public ProcessRunResult(string fileName, string arguments, int exitCode, string stdOut, string stdErr)
         {
             FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            Arguments = arguments;
             ExitCode = exitCode;
             StdOut = stdOut ?? string.Empty;
             StdErr = stdErr ?? string.Empty;
         }
 
         public string FileName { get; }
+        public string Arguments { get; }
+
         public string ProcessName => Path.GetFileName(FileName);
         public int ExitCode { get; }
         public string StdOut { get; }
@@ -23,7 +26,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
         {
             if (ExitCode == 0 && string.IsNullOrEmpty(StdErr)) return this;
 
-            throw new ProcessErrorException(ProcessName, ExitCode, StdOut, StdErr);
+            throw new ProcessErrorException(this);
         }
     }
 }

--- a/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessUtils.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessUtils.cs
@@ -16,6 +16,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
             if (string.IsNullOrWhiteSpace(fileName))
                 throw new ArgumentException(nameof(fileName), "File name must be specified.");
 
+            var escapedArguments = arguments is null ? null : EscapeProcessArguments(arguments, alwaysQuote: false);
+
             using (var process = new Process
             {
                 StartInfo =
@@ -23,7 +25,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                     UseShellExecute = false,
                     WorkingDirectory = workingDirectory,
                     FileName = fileName,
-                    Arguments = arguments is null ? null : EscapeProcessArguments(arguments, alwaysQuote: false),
+                    Arguments = escapedArguments,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true
                 }
@@ -67,6 +69,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
 
                 return new ProcessRunResult(
                     fileName,
+                    escapedArguments,
                     process.ExitCode,
                     stdout?.ToString(),
                     stderr?.ToString());


### PR DESCRIPTION
I've improved the exit code handling. The test failure message includes:

- Stdout, if stderr was whitespace 
- The exact command to run to reproduce the problem

This should go a long way in quickly dealing with acceptance test issues.

The only test that failed for me was the one that targeted `net47`. Visual Studio doesn't include it in its default install.

Because no useful error message was logged, I don't know why https://ci.appveyor.com/project/CharliePoole/nunit3-vs-adapter/builds/30058150 failed and practically identical further builds succeeded. One thing we can try if we see future MSBuild.exe failures is an additional `/nodeReuse:false` parameter, but I want to get to see the logged errors first.