### PR TITLE
Directory.DeleteDirectory(recursive: true) is non-atomic

### DIFF
--- a/src/NUnitTestAdapterTests/TempDirectory.cs
+++ b/src/NUnitTestAdapterTests/TempDirectory.cs
@@ -39,7 +39,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
 
         public void Dispose()
         {
-            Directory.Delete(Path, recursive: true);
+            Utils.DeleteDirectoryRobust(Path);
         }
 
         public static implicit operator string(TempDirectory tempDirectory) => tempDirectory.Path;

--- a/src/NUnitTestAdapterTests/Utils.cs
+++ b/src/NUnitTestAdapterTests/Utils.cs
@@ -1,0 +1,33 @@
+﻿using System.IO;
+using NUnit.Framework;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests
+{
+    internal static class Utils
+    {
+        public static void DeleteDirectoryRobust(string directory)
+        {
+            for (var attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                    break;
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    break;
+                }
+                catch (IOException ex) when (attempt < 3 && (WinErrorCode)ex.HResult == WinErrorCode.DirNotEmpty)
+                {
+                    TestContext.WriteLine("Another process added files to the directory while its contents were being deleted. Retrying...");
+                }
+            }
+        }
+
+        private enum WinErrorCode : ushort
+        {
+            DirNotEmpty = 145
+        }
+    }
+}


### PR DESCRIPTION
Re: https://nunit.visualstudio.com/NUnit/_build/results?buildId=2517&view=ms.vss-test-web.build-test-results-tab

I don't have any idea what causes this problem in general. Sometimes it's antivirus or Windows Explorer (obviously not in the case of CI). Maybe a file was locked?

I typically end up using this helper eventually anywhere I use Directory.DeleteDirectory. Another approach we could take is to make it warn if it fails since it does not indicate an error in the SUT, just leftovers in %TEMP% that weren't cleaned up after the test succeeded.