### PR TITLE
All builds should use services from the engine, rather than creating standalone services

### DIFF
--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -349,11 +349,8 @@ namespace NUnit.VisualStudio.TestAdapter
                 return;
 
             string path = Path.Combine(TestOutputXmlFolder, $"{Path.GetFileNameWithoutExtension(assemblyPath)}.xml");
-#if NET35
             var resultService = NUnitEngineAdapter.GetService<IResultService>();
-#else
-            var resultService = new ResultService();
-#endif
+
             // Following null argument should work for nunit3 format. Empty array is OK as well.
             // If you decide to handle other formats in the runsettings, it needs more work.
             var resultWriter = resultService.GetResultWriter("nunit3", null);
@@ -363,11 +360,7 @@ namespace NUnit.VisualStudio.TestAdapter
 
         private NUnitTestFilterBuilder CreateTestFilterBuilder()
         {
-#if !NET35
-            return new NUnitTestFilterBuilder(new TestFilterService());
-#else
             return new NUnitTestFilterBuilder(NUnitEngineAdapter.GetService<ITestFilterService>());
-#endif
         }
 
 


### PR DESCRIPTION
This fixes a problem that @OsirisTerje was having when working on #667. The adapter should use the services created by the engine, rather than initializing any standalone services. This code is probably a workaround, from when the .NET Standard engine was less developed.

The exact issue was that the standalone ResultService created had no reference to the engine's extension service, so was not aware of any resultwriter extensions. Requesting the service form the engine instead provides a service which has been initialised in a specific way, to ensure this happens correctly.

This type of issue wouldn't be possible, if the adapter was referencing the engine through the nunit.engine.api assembly, rather than directly. Hopefully at some point, we can convert it over to do that. 🙂 