### PR TITLE
Upgraded Engine to 3.11.1

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -251,7 +251,8 @@ Task("CreateWorkingImage")
             ADAPTER_BIN_DIR_NET35 + "NUnit3.TestAdapter.dll",
             ADAPTER_BIN_DIR_NET35 + "NUnit3.TestAdapter.pdb",
             ADAPTER_BIN_DIR_NET35 + "nunit.engine.dll",
-            ADAPTER_BIN_DIR_NET35 + "nunit.engine.api.dll"
+            ADAPTER_BIN_DIR_NET35 + "nunit.engine.api.dll",
+            ADAPTER_BIN_DIR_NET35 + "nunit.engine.core.dll"
         };
 
         var net35Dir = PACKAGE_IMAGE_DIR + "build/net35";

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -44,12 +44,14 @@
         <file src="build\net35\NUnit3.TestAdapter.pdb" target="build\net35\NUnit3.TestAdapter.pdb" />
         <file src="build\net35\nunit.engine.dll" target="build\net35\nunit.engine.dll" />
         <file src="build\net35\nunit.engine.api.dll" target="build\net35\nunit.engine.api.dll" />
+        <file src="build\net35\nunit.engine.core.dll" target="build\net35\nunit.engine.core.dll" />
         <file src="build\net35\NUnit3TestAdapter.props" target="build\net35\NUnit3TestAdapter.props" />
 
         <file src="build\netcoreapp2.1\NUnit3.TestAdapter.dll" target="build\netcoreapp2.1\NUnit3.TestAdapter.dll" />
         <file src="build\netcoreapp2.1\NUnit3.TestAdapter.pdb" target="build\netcoreapp2.1\NUnit3.TestAdapter.pdb" />
         <file src="build\netcoreapp2.1\nunit.engine.dll" target="build\netcoreapp2.1\nunit.engine.dll" />
         <file src="build\netcoreapp2.1\nunit.engine.api.dll" target="build\netcoreapp2.1\nunit.engine.api.dll" />
+        <file src="build\netcoreapp2.1\nunit.engine.core.dll" target="build\netcoreapp2.1\nunit.engine.core.dll" />
         <file src="build\netcoreapp2.1\NUnit3TestAdapter.props" target="build\netcoreapp2.1\NUnit3TestAdapter.props" />
 
     </files>

--- a/nuget/net35/NUnit3TestAdapter.props
+++ b/nuget/net35/NUnit3TestAdapter.props
@@ -21,5 +21,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)nunit.engine.core.dll">
+      <Link>nunit.engine.core.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
   </ItemGroup>
 </Project>

--- a/nuget/netcoreapp2.1/NUnit3TestAdapter.props
+++ b/nuget/netcoreapp2.1/NUnit3TestAdapter.props
@@ -21,5 +21,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>False</Visible>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)nunit.engine.core.dll">
+      <Link>nunit.engine.core.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.10.0" />
+    <PackageReference Include="nunit.engine" Version="3.11.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">


### PR DESCRIPTION
Closes #745 

I would appreciate a second look or beta on this.

I tested this both by dog-fooding the adapter while resolving other issues as well as running the following:

`build -c debug -t test`

It is assumed that that is the way to invoke all tests.

The results showed as follows:

```
========================================
Test
========================================

Task                          Duration
--------------------------------------------------
Build                         00:00:05.4600111
VSTest-net46                  00:00:13.3946013
VSTest-netcoreapp2.1          00:00:04.4253227
DotnetTest-net46              00:00:11.4834360
DotnetTest-netcoreapp2.1      00:00:06.3658287
--------------------------------------------------
Total:                        00:00:41.1325526
```

However it was noted that several tests were skipped, but they seem to be skipped in master as well?

The change itself was a little more tricky than simply bumping the package version, the DLL's that ship with the Engine have changed between 3.10 and 3.11.1 to include an additional DLL (`nunit.engine.core.dll`) it is believed both the net35 and netcoreapp2.1 packages need this, however I do not develop netcore2.1 apps and have no test bed for it.