### PR TITLE
Upgraded Engine to 3.11.1 - Fix Missing Dependency From VSIX

### DIFF
--- a/src/NUnit3TestAdapterInstall/NUnit3TestAdapterInstall.csproj
+++ b/src/NUnit3TestAdapterInstall/NUnit3TestAdapterInstall.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <VsixSourceItem Include="$(VsixInputFileLocation)\nunit.engine.api.dll" />
     <VsixSourceItem Include="$(VsixInputFileLocation)\nunit.engine.dll" />
+    <VsixSourceItem Include="$(VsixInputFileLocation)\nunit.engine.core.dll" />
     <VsixSourceItem Include="$(VsixInputFileLocation)\NUnit3.TestAdapter.dll" />
     <VsixSourceItem Include="$(VsixInputFileLocation)\NUnit3.TestAdapter.pdb" />
   </ItemGroup>


### PR DESCRIPTION
These items were missed on PR #749; this would have caused the VSIX Install package to Fail with a missing assembly.