### PR TITLE
Remove unnecessary package dependencies.

### DIFF
--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -5,7 +5,7 @@
         <version>$version$</version>
         <title>NUnit 3 Test Adapter for Visual Studio and DotNet</title>
         <authors>Charlie Poole, Terje Sandstrom</authors>
-        <license type="file">LICENSE.txt</license>
+        <license type="expression">MIT</license>
         <projectUrl>https://github.com/nunit/docs/wiki/Visual-Studio-Test-Adapter</projectUrl>
         <repository type="git" url="https://github.com/nunit/nunit3-vs-adapter"/>
         <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
@@ -25,22 +25,8 @@
         <tags>test visualstudio testadapter nunit nunit3 dotnet</tags>
 
         <developmentDependency>false</developmentDependency>
-        <dependencies>
-            <group targetFramework="netcoreapp2.1">
-                <dependency id="Microsoft.DotNet.InternalAbstractions" version="1.0.0" />
-                <dependency id="System.ComponentModel.EventBasedAsync" version="4.3.0" />
-                <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" />
-                <dependency id="System.Diagnostics.Process" version="4.3.0" />
-                <dependency id="System.Reflection" version="4.3.0" />
-                <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
-                <dependency id="System.Threading.Thread" version="4.3.0" />
-                <dependency id="System.Xml.XmlDocument" version="4.3.0" />
-                <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" />
-            </group>
-        </dependencies>
     </metadata>
     <files>
-        <file src="LICENSE.txt" />
         <file src="build\net35\NUnit3.TestAdapter.dll" target="build\net35\NUnit3.TestAdapter.dll" />
         <file src="build\net35\NUnit3.TestAdapter.pdb" target="build\net35\NUnit3.TestAdapter.pdb" />
         <file src="build\net35\nunit.engine.dll" target="build\net35\nunit.engine.dll" />

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -43,8 +43,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.0.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #785.
These dependencies are for .NET Standard 1.x dependencies and for .NET Core 2.1 they just bloat the package dependency stream for no reason.
And use an SPDX license expression to identify the license as MIT.

I would especially appreciate if this PR was marked with a `hacktoberfest-accepted` label.