### PR TITLE
[ProcessUtils] Simplify reading the process sdtout and stderr.

### DIFF
--- a/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessUtils.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessUtils.cs
@@ -45,7 +45,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                 {
                     if (e.Data is null) return;
 
-                    stdout.AppendLine();
+                    if (stdout.Length != 0)
+                        stdout.AppendLine();
+
                     stdout.Append(e.Data);
                 };
 
@@ -53,7 +55,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                 {
                     if (e.Data is null) return;
 
-                    stderr.AppendLine();
+                    if (stderr.Length != 0)
+                        stderr.AppendLine();
+
                     stderr.Append(e.Data);
                 };
 
@@ -66,8 +70,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                     fileName,
                     escapedArguments,
                     process.ExitCode,
-                    stdout.ToString(),
-                    stderr.ToString());
+                    stdout.Length != 0 ? stdout.ToString() : null,
+                    stderr.Length != 0 ? stderr.ToString() : null);
             }
         }
 

--- a/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessUtils.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessUtils.cs
@@ -35,18 +35,17 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                 // It breaks MSBuild 15’s targets when it tries to build legacy csprojs and vbprojs.
                 process.StartInfo.EnvironmentVariables.Remove("VisualStudioVersion");
 
-                var stdout = (StringBuilder)null;
-                var stderr = (StringBuilder)null;
+                // stdout and stderr is always redirected, as such these can be newed up here
+                // so the events would not need to check if it's null or not and then just
+                // immediately use it instead.
+                var stdout = new StringBuilder();
+                var stderr = new StringBuilder();
 
                 process.OutputDataReceived += (sender, e) =>
                 {
                     if (e.Data is null) return;
 
-                    if (stdout is null)
-                        stdout = new StringBuilder();
-                    else
-                        stdout.AppendLine();
-
+                    stdout.AppendLine();
                     stdout.Append(e.Data);
                 };
 
@@ -54,11 +53,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                 {
                     if (e.Data is null) return;
 
-                    if (stderr is null)
-                        stderr = new StringBuilder();
-                    else
-                        stderr.AppendLine();
-
+                    stderr.AppendLine();
                     stderr.Append(e.Data);
                 };
 
@@ -71,8 +66,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                     fileName,
                     escapedArguments,
                     process.ExitCode,
-                    stdout?.ToString(),
-                    stderr?.ToString());
+                    stdout.ToString(),
+                    stderr.ToString());
             }
         }
 

--- a/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessUtils.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/WorkspaceTools/ProcessUtils.cs
@@ -35,9 +35,6 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance.WorkspaceTools
                 // It breaks MSBuild 15’s targets when it tries to build legacy csprojs and vbprojs.
                 process.StartInfo.EnvironmentVariables.Remove("VisualStudioVersion");
 
-                // stdout and stderr is always redirected, as such these can be newed up here
-                // so the events would not need to check if it's null or not and then just
-                // immediately use it instead.
                 var stdout = new StringBuilder();
                 var stderr = new StringBuilder();
 


### PR DESCRIPTION
@jnm2 pointed me to this code where later I realized in reading it that it could be simplified further so then the events do not need to allocate the actual objects.

The result is the exact same as where if an event is never executed (the process never outputs to stdout or stderr then the builder's ``ToString()`` method will return string.Empty.

I do not think this will be a breaking change since most people check if strings are null or empty using ``string.IsNullOrEmpty()`` anyway so.

Fixes #844.