### PR TITLE
Adding test name in console output

### DIFF
--- a/src/NUnitTestAdapter/Metadata/DirectReflectionMetadataProvider.cs
+++ b/src/NUnitTestAdapter/Metadata/DirectReflectionMetadataProvider.cs
@@ -95,10 +95,9 @@ namespace NUnit.VisualStudio.TestAdapter.Metadata
 #endif
 
                 var type = assembly.GetType(reflectedTypeName, throwOnError: false);
-                if (type == null) return null;
 
-                var methods = type.GetMethods().Where(m => m.Name == methodName).Take(2).ToList();
-                return methods.Count == 1 ? methods[0] : null;
+                var methods = type?.GetMethods().Where(m => m.Name == methodName).Take(2).ToList();
+                return methods?.Count == 1 ? methods[0] : null;
             }
             catch (FileNotFoundException)
             {

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -29,13 +29,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="..\..\LICENSE.txt" Link="LICENSE.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.12.0"  />
-    <PackageReference Include="TestCentric.Metadata" Version="1.4.1" Aliases="TestCentric"/>
+    <PackageReference Include="nunit.engine" Version="3.12.0" />
+    <PackageReference Include="TestCentric.Metadata" Version="1.4.1" Aliases="TestCentric" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net35'">

--- a/src/NUnitTestAdapter/NUnitEngine/DiscoveryConverter.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/DiscoveryConverter.cs
@@ -93,8 +93,8 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
 
         public string AssemblyPath { get; private set; }
 
-        IAdapterSettings Settings { get; }
-        ITestLogger TestLog { get; }
+        private IAdapterSettings Settings { get; }
+        private ITestLogger TestLog { get; }
 
         public bool NoOfLoadedTestCasesAboveLimit => NoOfLoadedTestCases > Settings.AssemblySelectLimit;
         public IEnumerable<TestCase> CheckTestCasesExplicit(IEnumerable<TestCase> filteredTestCases)
@@ -163,15 +163,10 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             timing.LogTime("Converting test cases ");
             return loadedTestCases;
 
-            IEnumerable<NUnitDiscoveryTestCase> RunnableTestCases(bool isExplicit)
-            {
-                IEnumerable<NUnitDiscoveryTestCase> result;
-                if (isExplicit || !Settings.DesignMode)
-                    result = TestRun.TestAssembly.AllTestCases;
-                else
-                    result = TestRun.TestAssembly.RunnableTestCases;
-                return result;
-            }
+            IEnumerable<NUnitDiscoveryTestCase> RunnableTestCases(bool isExplicit) =>
+                isExplicit || !Settings.DesignMode
+                    ? TestRun.TestAssembly.AllTestCases
+                    : TestRun.TestAssembly.RunnableTestCases;
         }
 
         public NUnitDiscoveryTestRun ConvertXml(NUnitResults discovery)
@@ -192,11 +187,17 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             return ts;
         }
 
-        private static void ExtractAllFixtures(NUnitDiscoveryTestSuite parent, XElement node)
+        private void ExtractAllFixtures(NUnitDiscoveryTestSuite parent, XElement node)
         {
             foreach (var child in node.Elements("test-suite"))
             {
-                var type = child.Attribute(NUnitXmlAttributeNames.Type).Value;
+                var type = child.Attribute(NUnitXmlAttributeNames.Type)?.Value;
+                if (type == null)
+                {
+                    TestLog.Debug($"ETF1:Don't understand element: {child}");
+                    continue;
+                }
+
                 var className = child.Attribute(NUnitXmlAttributeNames.Classname)?.Value;
                 switch (type)
                 {
@@ -233,11 +234,16 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             }
         }
 
-        private static void ExtractTestFixtures(NUnitDiscoveryCanHaveTestFixture parent, XElement node)
+        private void ExtractTestFixtures(NUnitDiscoveryCanHaveTestFixture parent, XElement node)
         {
             foreach (var child in node.Elements().Where(o => o.Name != "properties"))
             {
-                var type = child.Attribute(NUnitXmlAttributeNames.Type).Value;
+                var type = child.Attribute(NUnitXmlAttributeNames.Type)?.Value;
+                if (type == null)
+                {
+                    TestLog.Debug($"ETF2:Don't understand element: {child}");
+                    continue;
+                }
                 var className = child.Attribute(NUnitXmlAttributeNames.Classname)?.Value;
                 var btf = ExtractSuiteBasePropertiesClass(child);
                 switch (type)
@@ -366,8 +372,8 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
 
         private NUnitDiscoveryTestAssembly ExtractTestAssembly(XElement node, NUnitDiscoveryTestRun parent)
         {
-            string dType = node.Attribute(NUnitXmlAttributeNames.Type).Value;
-            if (dType != "Assembly")
+            string dType = node.Attribute(NUnitXmlAttributeNames.Type)?.Value;
+            if (dType is not "Assembly")
                 throw new DiscoveryException("Node is not of type assembly: " + node);
             var aBase = ExtractSuiteBasePropertiesClass(node);
             var assembly = new NUnitDiscoveryTestAssembly(aBase, parent);

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitEventTestCase.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitEventTestCase.cs
@@ -59,7 +59,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
         public string ClassName => Node.GetAttribute("classname");
         public string MethodName => Node.GetAttribute("methodname");
 
-        RunStateEnum runState = RunStateEnum.NA;
+        private RunStateEnum runState = RunStateEnum.NA;
 
         public RunStateEnum RunState
         {

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -157,13 +157,19 @@ namespace NUnit.VisualStudio.TestAdapter
             }
 
             var result = _testConverter.GetVsTestResults(resultNode, outputNodes ?? EmptyNodes);
-            if (_settings.ConsoleOut == 1 && !string.IsNullOrEmpty(result.ConsoleOutput) && result.ConsoleOutput != NL)
+            if (_settings.ConsoleOut == 1)
             {
-                _recorder.SendMessage(TestMessageLevel.Informational, result.ConsoleOutput);
-            }
-            if (_settings.ConsoleOut == 1 && !string.IsNullOrEmpty(resultNode.ReasonMessage))
-            {
-                _recorder.SendMessage(TestMessageLevel.Informational, $"{resultNode.Name}: {resultNode.ReasonMessage}");
+                if (!string.IsNullOrEmpty(result.ConsoleOutput) && result.ConsoleOutput != NL)
+                {
+                    string msg = result.ConsoleOutput;
+                    if (_settings.UseTestNameInConsoleOutput)
+                        msg = $"{resultNode.Name}: {msg}";
+                    _recorder.SendMessage(TestMessageLevel.Informational, msg);
+                }
+                if (!string.IsNullOrEmpty(resultNode.ReasonMessage))
+                {
+                    _recorder.SendMessage(TestMessageLevel.Informational,                        $"{resultNode.Name}: {resultNode.ReasonMessage}");
+                }
             }
 
             _recorder.RecordEnd(result.TestCaseResult.TestCase, result.TestCaseResult.Outcome);

--- a/src/NUnitTestAdapterTests/VsExperimentalTests.cs
+++ b/src/NUnitTestAdapterTests/VsExperimentalTests.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2018-2018 Charlie Poole, Terje Sandstrom
+// Copyright (c) 2018 Charlie Poole, Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -24,8 +24,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using NSubstitute;
 using NUnit.Framework;


### PR DESCRIPTION
The Test Name is default added to the console output for tests. It can be turned off by the [UseTestNameInConsoleOutput]() runsetting.