### PR TITLE
Issue 965: Special build using pre-release of nunit.engine 4.0.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -12,7 +12,7 @@ var configuration = Argument("configuration", "Release");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "4.2.1";
+var version = "5.0.0";
 var modifier = "";
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";
@@ -101,7 +101,7 @@ Task("Clean")
 Task("CleanPackages")
     .Does(()=>
     {
-    CleanDirectory(PACKAGE_DIR);
+        CleanDirectory(PACKAGE_DIR);
     });
 
 //////////////////////////////////////////////////////////////////////

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -22,9 +22,17 @@
     <DisableHandlePackageFileConflicts>false</DisableHandlePackageFileConflicts>
   </PropertyGroup>
 
+  <!-- We reference a specific pre-release version of the nunit.engine -->
+  <PropertyGroup>
+    <RestoreAdditionalProjectSources>https://www.myget.org/F/nunit/api/v3/index.json</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit.engine" Version="4.0.0-dev00100" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.13.2" />
     <PackageReference Include="TestCentric.Metadata" Version="1.7.1" Aliases="TestCentric" />
   </ItemGroup>
 

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -24,7 +24,7 @@
 
   <!-- We reference a specific pre-release version of the nunit.engine -->
   <PropertyGroup>
-    <RestoreAdditionalProjectSources>https://www.myget.org/F/nunit/api/v3/index.json</RestoreAdditionalProjectSources>
+    <RestoreAdditionalProjectSource>https://www.myget.org/F/nunit/api/v3/index.json</RestoreAdditionalProjectSource>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitTestAdapter/NUnitEngine/DiscoveryConverter.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/DiscoveryConverter.cs
@@ -412,8 +412,10 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
         private static BaseProperties ExtractSuiteBasePropertiesClass(XElement node)
         {
             string dId = node.Attribute(NUnitXmlAttributeNames.Id).Value;
-            string dName = node.Attribute(NUnitXmlAttributeNames.Name).Value;
-            string dFullname = node.Attribute(NUnitXmlAttributeNames.Fullname).Value;
+
+            // test-run no longer has a name/fullname property
+            string dName = node.Attribute(NUnitXmlAttributeNames.Name)?.Value ?? "Unnamed";
+            string dFullname = node.Attribute(NUnitXmlAttributeNames.Fullname)?.Value ?? "Unnamed";
             var dRunstate = ExtractRunState(node);
             const char apo = '\'';
             var tcs = node.Attribute(NUnitXmlAttributeNames.Testcasecount)?.Value.Trim(apo);

--- a/src/NUnitTestAdapterTests/NUnitEngineTests/NUnitDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEngineTests/NUnitDiscoveryTests.cs
@@ -13,7 +13,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.NUnitEngineTests
         private IAdapterSettings settings;
 
         private const string FullDiscoveryXml =
-            @"<test-run id='2' name='CSharpTestDemo.dll' fullname='D:\repos\NUnit\nunit3-vs-adapter-demo\solutions\vs2017\CSharpTestDemo\bin\Debug\CSharpTestDemo.dll' testcasecount='108'>
+            @"<test-run id='2' testcasecount='108'>
    <test-suite type='Assembly' id='0-1157' name='CSharpTestDemo.dll' fullname='D:\repos\NUnit\nunit3-vs-adapter-demo\solutions\vs2017\CSharpTestDemo\bin\Debug\CSharpTestDemo.dll' runstate='Runnable' testcasecount='108'>
       <properties>
          <property name='_PID' value='9856' />

--- a/src/NUnitTestAdapterTests/TestAdapterUtils.cs
+++ b/src/NUnitTestAdapterTests/TestAdapterUtils.cs
@@ -22,8 +22,8 @@
 // ***********************************************************************
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
 using NUnit.Engine.Services;
-using NUnit.Framework;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
 {
@@ -49,14 +49,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             adapter.NUnitEngineAdapter.InternalEngineCreated += engine =>
             {
                 var concreteEngineType = (NUnit.Engine.TestEngine)engine;
-                concreteEngineType.Services.Add(new SettingsService(true));
-                concreteEngineType.Services.Add(new DomainManager());
                 concreteEngineType.Services.Add(new ExtensionService());
-                concreteEngineType.Services.Add(new DriverService());
-                concreteEngineType.Services.Add(new RecentFilesService());
                 concreteEngineType.Services.Add(new ProjectService());
                 concreteEngineType.Services.Add(new RuntimeFrameworkService());
-                concreteEngineType.Services.Add(new DefaultTestRunnerFactory());
                 concreteEngineType.Services.Add(new TestAgency()); // "TestAgency for " + TestContext.CurrentContext.Test.Name, 0));
                 concreteEngineType.Services.Add(new ResultService());
                 concreteEngineType.Services.Add(new TestFilterService());


### PR DESCRIPTION
Fixes #965 

I left this as a draft PR as I don't expect it to be merged into master.
The purpose is to get a special build that can be referenced in nunit framework nunit4 developments.

As I also not aware of the changes in the engine, I have deleted several lines in `TestAdapterUtils` as those classes no longer exist.

There was one other change. The name/fullname properties of the test-run node seem to no longer exist.

I testes the nuget package with nunit framework and it allows me to run tests in VS and with `dotnet test`