### PR TITLE
Unescape \u in test output so ANSI color codes can be interpreted correctly 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,11 @@ jobs:
     pool:
       vmImage: 'windows-latest'
     steps:
+    - task: UseDotNet@2
+      displayName: Install .NET Core 2.1 runtime
+      inputs:
+        packageType: runtime
+        version: 2.1.x
     - powershell: .\build.ps1 --target=CI --configuration=$(BuildConfiguration)
       displayName: Build, package, and test
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,9 +22,15 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
     - task: UseDotNet@2
-      displayName: Install required .NET Core SDK
+      displayName: Install .NET Core 6.0 sdk
       inputs:
-        useGlobalJson: true
+        version: 6.x
+
+    - task: UseDotNet@2
+      displayName: Install .NET Core 5.0 runtime
+      inputs:
+        packageType: runtime
+        version: 5.x
 
     - task: UseDotNet@2
       displayName: Install .NET Core 3.1 runtime

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitTestEvent.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitTestEvent.cs
@@ -127,7 +127,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
 
         public string MethodName => Node.GetAttribute("methodname");
         public string ClassName => Node.GetAttribute("classname");
-        public string Output => UnicodeEscapeHelper.UnEscapeUnicodeCharacters(Node.SelectSingleNode("output")?.InnerText);
+        public string Output => Node.SelectSingleNode("output")?.InnerText.UnEscapeUnicodeCharacters();
 
 
         public CheckedTime StartTime()
@@ -165,7 +165,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
                 foreach (XmlNode attachment in Node.SelectNodes("attachments/attachment"))
                 {
                     var path = attachment.SelectSingleNode("filePath")?.InnerText ?? string.Empty;
-                    var description = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(attachment.SelectSingleNode("description")?.InnerText);
+                    var description = attachment.SelectSingleNode("description")?.InnerText.UnEscapeUnicodeCharacters();
                     nUnitAttachments.Add(new NUnitAttachment(path, description));
                 }
                 return nUnitAttachments;

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitTestEvent.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitTestEvent.cs
@@ -127,7 +127,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
 
         public string MethodName => Node.GetAttribute("methodname");
         public string ClassName => Node.GetAttribute("classname");
-        public string Output => Node.SelectSingleNode("output")?.InnerText;
+        public string Output => UnicodeEscapeHelper.UnEscapeUnicodeCharacters(Node.SelectSingleNode("output")?.InnerText);
 
 
         public CheckedTime StartTime()
@@ -165,7 +165,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
                 foreach (XmlNode attachment in Node.SelectNodes("attachments/attachment"))
                 {
                     var path = attachment.SelectSingleNode("filePath")?.InnerText ?? string.Empty;
-                    var description = attachment.SelectSingleNode("description")?.InnerText;
+                    var description = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(attachment.SelectSingleNode("description")?.InnerText);
                     nUnitAttachments.Add(new NUnitAttachment(path, description));
                 }
                 return nUnitAttachments;

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventSuiteFinished.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventSuiteFinished.cs
@@ -28,10 +28,10 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             var failureNode = Node.SelectSingleNode("failure");
             if (failureNode != null)
             {
-                FailureMessage = failureNode.SelectSingleNode("message")?.InnerText;
-                StackTrace = failureNode.SelectSingleNode("stack-trace")?.InnerText;
+                FailureMessage = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(failureNode.SelectSingleNode("message")?.InnerText);
+                StackTrace = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(failureNode.SelectSingleNode("stack-trace")?.InnerText);
             }
-            ReasonMessage = Node.SelectSingleNode("reason/message")?.InnerText;
+            ReasonMessage = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(Node.SelectSingleNode("reason/message")?.InnerText);
         }
 
         public string ReasonMessage { get; }

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventSuiteFinished.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventSuiteFinished.cs
@@ -28,10 +28,10 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             var failureNode = Node.SelectSingleNode("failure");
             if (failureNode != null)
             {
-                FailureMessage = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(failureNode.SelectSingleNode("message")?.InnerText);
-                StackTrace = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(failureNode.SelectSingleNode("stack-trace")?.InnerText);
+                FailureMessage = failureNode.SelectSingleNode("message")?.InnerText.UnEscapeUnicodeCharacters();
+                StackTrace = failureNode.SelectSingleNode("stack-trace")?.InnerText.UnEscapeUnicodeCharacters();
             }
-            ReasonMessage = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(Node.SelectSingleNode("reason/message")?.InnerText);
+            ReasonMessage = Node.SelectSingleNode("reason/message")?.InnerText.UnEscapeUnicodeCharacters();
         }
 
         public string ReasonMessage { get; }

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventTestCase.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventTestCase.cs
@@ -1,4 +1,7 @@
-﻿using System.Xml;
+﻿using System;
+using System.Globalization;
+using System.Text;
+using System.Xml;
 
 namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
 {
@@ -17,23 +20,25 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
     }
 
 
-
     /// <summary>
     /// Handles the NUnit 'test-case' event.
     /// </summary>
     public class NUnitTestEventTestCase : NUnitTestEvent, INUnitTestEventTestCase
     {
-        public NUnitTestEventTestCase(INUnitTestEventForXml node) : this(node.Node)
+        public NUnitTestEventTestCase(INUnitTestEventForXml node)
+            : this(node.Node)
         {
         }
 
-        public NUnitTestEventTestCase(string testEvent) : this(XmlHelper.CreateXmlNode(testEvent))
+        public NUnitTestEventTestCase(string testEvent)
+            : this(XmlHelper.CreateXmlNode(testEvent))
         {
         }
 
         public NUnitFailure Failure { get; }
 
-        public NUnitTestEventTestCase(XmlNode node) : base(node)
+        public NUnitTestEventTestCase(XmlNode node)
+            : base(node)
         {
             if (node.Name != "test-case")
                 throw new NUnitEventWrongTypeException($"Expected 'test-case', got {node.Name}");
@@ -41,12 +46,12 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             if (failureNode != null)
             {
                 Failure = new NUnitFailure(
-                    failureNode.SelectSingleNode("message")?.InnerText,
-                    failureNode.SelectSingleNode("stack-trace")?.InnerText);
+                    UnicodeEscapeHelper.UnEscapeUnicodeCharacters(failureNode.SelectSingleNode("message")?.InnerText),
+                    UnicodeEscapeHelper.UnEscapeUnicodeCharacters(failureNode.SelectSingleNode("stack-trace")?.InnerText));
             }
-            ReasonMessage = Node.SelectSingleNode("reason/message")?.InnerText;
-        }
 
+            ReasonMessage = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(Node.SelectSingleNode("reason/message")?.InnerText);
+        }
         public string ReasonMessage { get; }
 
         public bool HasReason => !string.IsNullOrEmpty(ReasonMessage);
@@ -62,7 +67,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
                 string stackTrace = string.Empty;
                 foreach (XmlNode assertionStacktraceNode in Node.SelectNodes("assertions/assertion/stack-trace"))
                 {
-                    stackTrace += assertionStacktraceNode.InnerText;
+                    stackTrace += UnicodeEscapeHelper.UnEscapeUnicodeCharacters(assertionStacktraceNode.InnerText);
                 }
 
                 return stackTrace;

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventTestCase.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventTestCase.cs
@@ -46,11 +46,11 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             if (failureNode != null)
             {
                 Failure = new NUnitFailure(
-                    UnicodeEscapeHelper.UnEscapeUnicodeCharacters(failureNode.SelectSingleNode("message")?.InnerText),
-                    UnicodeEscapeHelper.UnEscapeUnicodeCharacters(failureNode.SelectSingleNode("stack-trace")?.InnerText));
+                    failureNode.SelectSingleNode("message")?.InnerText.UnEscapeUnicodeCharacters(),
+                    failureNode.SelectSingleNode("stack-trace")?.InnerText.UnEscapeUnicodeCharacters());
             }
 
-            ReasonMessage = UnicodeEscapeHelper.UnEscapeUnicodeCharacters(Node.SelectSingleNode("reason/message")?.InnerText);
+            ReasonMessage = Node.SelectSingleNode("reason/message")?.InnerText.UnEscapeUnicodeCharacters();
         }
         public string ReasonMessage { get; }
 
@@ -67,7 +67,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
                 string stackTrace = string.Empty;
                 foreach (XmlNode assertionStacktraceNode in Node.SelectNodes("assertions/assertion/stack-trace"))
                 {
-                    stackTrace += UnicodeEscapeHelper.UnEscapeUnicodeCharacters(assertionStacktraceNode.InnerText);
+                    stackTrace += assertionStacktraceNode.InnerText.UnEscapeUnicodeCharacters();
                 }
 
                 return stackTrace;

--- a/src/NUnitTestAdapter/NUnitEngine/UnicodeEscapeHelper.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/UnicodeEscapeHelper.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
+{
+    public class UnicodeEscapeHelper
+    {
+        public static string UnEscapeUnicodeCharacters(string text)
+        {
+            if (text == null)
+                return null;
+
+            // Small optimization, if there are no "\u", then there is no need to rewrite the string
+            var firstEscapeIndex = text.IndexOf("\\u", StringComparison.Ordinal);
+            if (firstEscapeIndex == -1)
+                return text;
+
+            var stringBuilder = new StringBuilder(text.Substring(0, firstEscapeIndex));
+            for (var position = firstEscapeIndex; position < text.Length; position++)
+            {
+                char c = text[position];
+                if (c == '\\' && TryUnEscapeOneCharacter(text, position, out var escapedChar, out var extraCharacterRead))
+                {
+                    stringBuilder.Append(escapedChar);
+                    position += extraCharacterRead;
+                }
+                else
+                {
+                    stringBuilder.Append(c);
+                }
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        private static bool TryUnEscapeOneCharacter(string text, int position, out char escapedChar, out int extraCharacterRead)
+        {
+            const string unicodeEscapeSample = "u0000";
+
+            extraCharacterRead = 0;
+            escapedChar = '\0';
+            if (position + unicodeEscapeSample.Length >= text.Length)
+                return false;
+
+
+            extraCharacterRead = unicodeEscapeSample.Length;
+            if (!int.TryParse(text.Substring(position + 2, unicodeEscapeSample.Length - 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var escapeValue))
+                return false;
+
+            escapedChar = (char)escapeValue;
+
+            return true;
+        }
+    }
+}

--- a/src/NUnitTestAdapter/NUnitEngine/UnicodeEscapeHelper.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/UnicodeEscapeHelper.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
 {
-    public class UnicodeEscapeHelper
+    internal static class UnicodeEscapeHelper
     {
-        public static string UnEscapeUnicodeCharacters(string text)
+        public static string UnEscapeUnicodeCharacters(this string text)
         {
             if (text == null)
                 return null;

--- a/src/NUnitTestAdapterTests/CurrentDirectoryTests.cs
+++ b/src/NUnitTestAdapterTests/CurrentDirectoryTests.cs
@@ -32,6 +32,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [TestCase(@"C:\Windows\Whatever")]
         [TestCase(@"C:\Program Files\Something")]
         [TestCase(@"C:\Program Files (x86)\Something")]
+        [Platform("Win")]
         public void ThatWeFindForbiddenFolders(string folder)
         {
             var sut = new NUnit3TestExecutor();

--- a/src/NUnitTestAdapterTests/DumpXmlTests.cs
+++ b/src/NUnitTestAdapterTests/DumpXmlTests.cs
@@ -65,7 +65,21 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [TestCase(@"C:\MyFolder\Whatever.dll", @"C:\MyFolder\Dump\D_Whatever.dll.dump")]
         [TestCase(@"C:\MyFolder\Whatever.dll", @"C:\MyFolder\Dump")]
         [TestCase(@"C:\MyFolder\Whatever.dll", @"C:\MyFolder")]
+        [Platform("Win")]
         public void ThatPathIsCorrectlyParsedInDiscoveryPhase(string path, string expected)
+        {
+            var file = Substitute.For<IFile>();
+            var sut = new DumpXml(path, file);
+            sut.AddString("whatever");
+            sut.DumpForDiscovery();
+            file.Received().WriteAllText(Arg.Is<string>(o => o.StartsWith(expected, StringComparison.OrdinalIgnoreCase)), Arg.Any<string>());
+        }
+
+        [TestCase(@"/some/Folder/Whatever.dll", @"/some/Folder/Dump/D_Whatever.dll.dump")]
+        [TestCase(@"/some/Folder/Whatever.dll", @"/some/Folder/Dump")]
+        [TestCase(@"/some/Folder/Whatever.dll", @"/some/Folder")]
+        [Platform("Unix")]
+        public void ThatPathIsCorrectlyParsedInDiscoveryPhaseOnUnix(string path, string expected)
         {
             var file = Substitute.For<IFile>();
             var sut = new DumpXml(path, file);

--- a/src/NUnitTestAdapterTests/NUnitEngineTests/UnicodeEscapeHelperTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEngineTests/UnicodeEscapeHelperTests.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using NUnit.VisualStudio.TestAdapter.NUnitEngine;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests.NUnitEngineTests
+{
+    public class UnicodeEscapeHelperTests
+    {
+        [TestCase("\\u001b", "\u001b")]
+        [TestCase("\\u001", "\\u001")]
+        [TestCase("\\u01", "\\u01")]
+        [TestCase("\\u1", "\\u1")]
+        [TestCase("\\u001b6", "\u001b6")]
+        [TestCase("some-text", "some-text")]
+        public void UnEscapeUnicodeCharacters_ShouldReplaceBackslashU(string value, string expected)
+        {
+            Assert.That(UnicodeEscapeHelper.UnEscapeUnicodeCharacters(value), Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/NUnitTestAdapterTests/NUnitEngineTests/UnicodeEscapeHelperTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEngineTests/UnicodeEscapeHelperTests.cs
@@ -13,7 +13,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.NUnitEngineTests
         [TestCase("some-text", "some-text")]
         public void UnEscapeUnicodeCharacters_ShouldReplaceBackslashU(string value, string expected)
         {
-            Assert.That(UnicodeEscapeHelper.UnEscapeUnicodeCharacters(value), Is.EqualTo(expected));
+            Assert.That(value.UnEscapeUnicodeCharacters(), Is.EqualTo(expected));
         }
     }
 }


### PR DESCRIPTION
It fix https://github.com/nunit/nunit/issues/4126
Maybe it fix but I'm not sure it's exactly the same problem https://github.com/nunit/nunit/issues/1787