### PR TITLE
WIP  Changes to allow for using NUnit.Engine 4 pre-release to support Net7…

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -12,7 +12,7 @@ var configuration = Argument("configuration", "Release");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "4.3.0";
+var version = "4.3.0-alpha-net7";
 var modifier = "";
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";

--- a/build.cake
+++ b/build.cake
@@ -12,7 +12,7 @@ var configuration = Argument("configuration", "Release");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "4.3.0-alpha-net7";
+var version = "4.3.0-alpha-net7.4";
 var modifier = "";
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Local" value="C:\nuget" />
+    <!--<add key="Local" value="C:\nuget" />-->
     <!--<add key="dev" value="https://www.myget.org/F/nunit/api/v3/index.json" />-->
     <add key="nuget" value="https://api.nuget.org/v3/index.json"/>
   </packageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,8 @@
 <configuration>
   <packageSources>
     <clear />
-    <!--<add key="Local" value="C:\nuget" />-->
-    <add key="dev" value="https://www.myget.org/F/nunit/api/v3/index.json" />
+    <add key="Local" value="C:\nuget" />
+    <!--<add key="dev" value="https://www.myget.org/F/nunit/api/v3/index.json" />-->
     <add key="nuget" value="https://api.nuget.org/v3/index.json"/>
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <!--<add key="Local" value="C:\nuget" />-->
+    <add key="dev" value="https://www.myget.org/F/nunit/api/v3/index.json" />
     <add key="nuget" value="https://api.nuget.org/v3/index.json"/>
   </packageSources>
 </configuration>

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -18,7 +18,7 @@
           For VS 2017 and forward, you should add this package to every test project in your solution. (Earlier versions only require a single adapter package per solution.)
         </description>
         <releaseNotes>See https://docs.nunit.org/articles/vs-test-adapter/Adapter-Release-Notes.html </releaseNotes>
-        <copyright>Copyright (c) 2011-2021 Charlie Poole, 2014-2021 Terje Sandstrom</copyright>
+        <copyright>Copyright (c) 2011-2021 Charlie Poole, 2014-2022 Terje Sandstrom</copyright>
         <language>en-US</language>
         <tags>test visualstudio testadapter nunit nunit3 dotnet</tags>
 

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit.engine" Version="4.0.0-dev00100" />
+        <PackageReference Include="nunit.engine" Version="3.16.0-alpha.2" />
     </ItemGroup>
 
   <PropertyGroup>

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -12,6 +12,14 @@
     <SourceLinkCreate>true</SourceLinkCreate>
   </PropertyGroup>
 
+    <PropertyGroup>
+        <RestoreAdditionalProjectSource>https://www.myget.org/F/nunit/api/v3/index.json</RestoreAdditionalProjectSource>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="nunit.engine" Version="4.0.0-dev00100" />
+    </ItemGroup>
+
   <PropertyGroup>
     <PackageId>NUnit3TestAdapter</PackageId>
     <Authors>Charlie Poole, Terje Sandstrom</Authors>
@@ -24,7 +32,6 @@
 
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.15.0" />
     <PackageReference Include="TestCentric.Metadata" Version="1.7.1" Aliases="TestCentric" />
   </ItemGroup>
 

--- a/src/NUnitTestAdapter/NUnitEngine/DiscoveryConverter.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/DiscoveryConverter.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2020-2021 Charlie Poole, Terje Sandstrom
+// Copyright (c) 2020-2021 Charlie Poole, 2020-2022 Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -414,7 +414,8 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             string dId = node.Attribute(NUnitXmlAttributeNames.Id).Value;
             // test-run no longer has a name/fullname property
             string dName = node.Attribute(NUnitXmlAttributeNames.Name)?.Value ?? "Unnamed";
-            string dFullname = node.Attribute(NUnitXmlAttributeNames.Fullname)?.Value ?? "Unnamed"; var dRunstate = ExtractRunState(node);
+            string dFullname = node.Attribute(NUnitXmlAttributeNames.Fullname)?.Value ?? "Unnamed";
+            var dRunstate = ExtractRunState(node);
             const char apo = '\'';
             var tcs = node.Attribute(NUnitXmlAttributeNames.Testcasecount)?.Value.Trim(apo);
             int dTestcasecount = int.Parse(tcs ?? "1", CultureInfo.InvariantCulture);

--- a/src/NUnitTestAdapter/NUnitEngine/DiscoveryConverter.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/DiscoveryConverter.cs
@@ -412,9 +412,9 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
         private static BaseProperties ExtractSuiteBasePropertiesClass(XElement node)
         {
             string dId = node.Attribute(NUnitXmlAttributeNames.Id).Value;
-            string dName = node.Attribute(NUnitXmlAttributeNames.Name).Value;
-            string dFullname = node.Attribute(NUnitXmlAttributeNames.Fullname).Value;
-            var dRunstate = ExtractRunState(node);
+            // test-run no longer has a name/fullname property
+            string dName = node.Attribute(NUnitXmlAttributeNames.Name)?.Value ?? "Unnamed";
+            string dFullname = node.Attribute(NUnitXmlAttributeNames.Fullname)?.Value ?? "Unnamed"; var dRunstate = ExtractRunState(node);
             const char apo = '\'';
             var tcs = node.Attribute(NUnitXmlAttributeNames.Testcasecount)?.Value.Trim(apo);
             int dTestcasecount = int.Parse(tcs ?? "1", CultureInfo.InvariantCulture);

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit.engine" Version="4.0.0-dev00100" />
+        <PackageReference Include="nunit.engine" Version="3.16.0-alpha.2" />
     </ItemGroup>
 
 

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -12,6 +12,16 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+    <PropertyGroup>
+        <RestoreAdditionalProjectSource>https://www.myget.org/F/nunit/api/v3/index.json</RestoreAdditionalProjectSource>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="nunit.engine" Version="4.0.0-dev00100" />
+    </ItemGroup>
+
+
+
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/src/NUnitTestAdapterTests/NUnitEngineTests/NUnitDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEngineTests/NUnitDiscoveryTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
 using System.Xml;
+
 using NSubstitute;
+
 using NUnit.Framework;
 using NUnit.VisualStudio.TestAdapter.NUnitEngine;
 // ReSharper disable StringLiteralTypo
@@ -13,8 +15,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.NUnitEngineTests
         private IAdapterSettings settings;
 
         private const string FullDiscoveryXml =
-            @"<test-run id='2' name='CSharpTestDemo.dll' fullname='D:\repos\NUnit\nunit3-vs-adapter-demo\solutions\vs2017\CSharpTestDemo\bin\Debug\CSharpTestDemo.dll' testcasecount='108'>
-   <test-suite type='Assembly' id='0-1157' name='CSharpTestDemo.dll' fullname='D:\repos\NUnit\nunit3-vs-adapter-demo\solutions\vs2017\CSharpTestDemo\bin\Debug\CSharpTestDemo.dll' runstate='Runnable' testcasecount='108'>
+            @"<test-run id='2' testcasecount='108'>
+     <test-suite type='Assembly' id='0-1157' name='CSharpTestDemo.dll' fullname='D:\repos\NUnit\nunit3-vs-adapter-demo\solutions\vs2017\CSharpTestDemo\bin\Debug\CSharpTestDemo.dll' runstate='Runnable' testcasecount='108'>
       <properties>
          <property name='_PID' value='9856' />
          <property name='_APPDOMAIN' value='domain-807ad471-CSharpTestDemo.dll' />

--- a/src/NUnitTestAdapterTests/TestAdapterUtils.cs
+++ b/src/NUnitTestAdapterTests/TestAdapterUtils.cs
@@ -51,13 +51,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             adapter.NUnitEngineAdapter.InternalEngineCreated += engine =>
             {
                 var concreteEngineType = (NUnit.Engine.TestEngine)engine;
-                concreteEngineType.Services.Add(new SettingsService(true));
                 concreteEngineType.Services.Add(new ExtensionService());
-                concreteEngineType.Services.Add(new DriverService());
-                concreteEngineType.Services.Add(new RecentFilesService());
                 concreteEngineType.Services.Add(new ProjectService());
                 concreteEngineType.Services.Add(new RuntimeFrameworkService());
-                concreteEngineType.Services.Add(new DefaultTestRunnerFactory());
                 concreteEngineType.Services.Add(new TestAgency()); // "TestAgency for " + TestContext.CurrentContext.Test.Name, 0));
                 concreteEngineType.Services.Add(new ResultService());
                 concreteEngineType.Services.Add(new TestFilterService());


### PR DESCRIPTION
… pre-release

See https://github.com/nunit/nunit3-vs-adapter/pull/966/files and https://github.com/nunit/nunit3-vs-adapter/issues/965
Thanks to [manfred-brands](https://github.com/manfred-brands) for the PR 966.  
Also note that this is just meant as a pre-release until the proper nunit.engine 4 is released, and is done in order to support .net 7 pre-release.  