### PR TITLE
Fix for issue 990

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var configuration = Argument("configuration", "Release");
 //////////////////////////////////////////////////////////////////////
 
 var version = "4.3.0";
-var modifier = "";
+var modifier = "-alpha-107";
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";
 var packageVersion = version + modifier + dbgSuffix;

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventTestCase.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitTestEventTestCase.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Text;
-using System.Xml;
+﻿using System.Xml;
 
 namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
 {
@@ -17,6 +14,11 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
         /// Find stacktrace in assertion nodes if not defined.
         /// </summary>
         string StackTrace { get; }
+
+        /// <summary>
+        /// Complete formatted stacktrace
+        /// </summary>
+        string FailureStackTrace { get; }
     }
 
 
@@ -57,6 +59,9 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
         public bool HasReason => !string.IsNullOrEmpty(ReasonMessage);
         public bool HasFailure => Failure != null;
 
+        public string FailureStackTrace => $"{Failure?.Stacktrace ?? ""}\n{StackTrace}";
+
+
         /// <summary>
         /// Find stacktrace in assertion nodes if not defined.
         /// </summary>
@@ -65,9 +70,11 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             get
             {
                 string stackTrace = string.Empty;
+                int i = 1;
                 foreach (XmlNode assertionStacktraceNode in Node.SelectNodes("assertions/assertion/stack-trace"))
                 {
-                    stackTrace += assertionStacktraceNode.InnerText.UnEscapeUnicodeCharacters();
+                    stackTrace += $"{i++}) " + assertionStacktraceNode.InnerText.UnEscapeUnicodeCharacters();
+                    stackTrace += "\n";
                 }
 
                 return stackTrace;

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2011-2021 Charlie Poole, Terje Sandstrom
+// Copyright (c) 2011-2021 Charlie Poole, 2011 - 2022 Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -25,9 +25,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+
 using NUnit.VisualStudio.TestAdapter.NUnitEngine;
+
 using VSTestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
 
 namespace NUnit.VisualStudio.TestAdapter
@@ -108,7 +111,7 @@ namespace NUnit.VisualStudio.TestAdapter
                     case TestOutcome.NotFound:
                         {
                             testCaseResult.ErrorMessage = resultNode.Failure?.Message;
-                            testCaseResult.ErrorStackTrace = resultNode.Failure?.Stacktrace ?? resultNode.StackTrace;
+                            testCaseResult.ErrorStackTrace = resultNode.FailureStackTrace;
                             break;
                         }
                     case TestOutcome.Skipped:

--- a/src/NUnitTestAdapter/TestConverterForXml.cs
+++ b/src/NUnitTestAdapter/TestConverterForXml.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2011-2021 Charlie Poole, Terje Sandstrom
+// Copyright (c) 2011-2021 Charlie Poole, 2011-2022 Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -132,7 +132,8 @@ namespace NUnit.VisualStudio.TestAdapter
                     case TestOutcome.NotFound:
                         {
                             testCaseResult.ErrorMessage = resultNode.Failure?.Message;
-                            testCaseResult.ErrorStackTrace = resultNode.Failure?.Stacktrace ?? resultNode.StackTrace;
+                            testCaseResult.ErrorStackTrace = resultNode.FailureStackTrace;
+
                             break;
                         }
                     case TestOutcome.Skipped:


### PR DESCRIPTION
Added stacktrace for inner exceptions, apparent in Assert.Multiple.  
Fix for #990 