### PR TITLE
Fixtmppath

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -2,7 +2,7 @@
 <RunSettings>
     <RunConfiguration>
         <!-- 0 = As many processes as possible, limited by number of cores on machine, 1 = Sequential (1 process), 2-> Given number of processes up to limit by number of cores on machine-->
-        <MaxCpuCount>0</MaxCpuCount>
+        <MaxCpuCount>1</MaxCpuCount>
 
     </RunConfiguration>
 

--- a/NUnit3TestAdapter.sln
+++ b/NUnit3TestAdapter.sln
@@ -61,6 +61,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\NUnit3TestAdapter.Cake.CI.yml = .github\workflows\NUnit3TestAdapter.Cake.CI.yml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcoreapp3.1", "netcoreapp3.1", "{2F940513-5B8F-45A5-A188-7C5D03D1B50D}"
+	ProjectSection(SolutionItems) = preProject
+		nuget\netcoreapp3.1\NUnit3TestAdapter.props = nuget\netcoreapp3.1\NUnit3TestAdapter.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -100,6 +105,7 @@ Global
 		{A9584E41-6ECE-44B4-A504-41795A65DA5F} = {DE347D88-F6ED-4031-AFC2-318F63E39BC9}
 		{062B1763-73C8-4B5A-92DF-C66A36C43CE1} = {7CE30108-5D81-4850-BE6B-C8BCA35D3592}
 		{7D708804-B2F1-4A31-A9FB-85A0C7433200} = {062B1763-73C8-4B5A-92DF-C66A36C43CE1}
+		{2F940513-5B8F-45A5-A188-7C5D03D1B50D} = {DE347D88-F6ED-4031-AFC2-318F63E39BC9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8EF03474-188E-44A8-8C76-9FBCF9A382EC}

--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var configuration = Argument("configuration", "Release");
 //////////////////////////////////////////////////////////////////////
 
 var version = "4.3.1";
-var modifier = "-alpha.111";
+var modifier = "";
 
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";
@@ -72,7 +72,7 @@ var BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
 
 var ADAPTER_PROJECT = SRC_DIR + "NUnitTestAdapter/NUnit.TestAdapter.csproj";
 
-var NETCOREAPP_TFM = "netcoreapp2.1";
+var NETCOREAPP_TFM = "netcoreapp3.1";
 
 var ADAPTER_BIN_DIR_NET35 = SRC_DIR + $"NUnitTestAdapter/bin/{configuration}/net35/";
 var ADAPTER_BIN_DIR_NETCOREAPP = SRC_DIR + $"NUnitTestAdapter/bin/{configuration}/{NETCOREAPP_TFM}/";

--- a/build.cake
+++ b/build.cake
@@ -12,8 +12,8 @@ var configuration = Argument("configuration", "Release");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "4.3.0";
-var modifier = "";
+var version = "4.3.1";
+var modifier = "-alpha.111";
 
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -1,45 +1,44 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
-    <metadata>
-        <id>NUnit3TestAdapter</id>
-        <version>$version$</version>
-        <title>NUnit3 Test Adapter for Visual Studio and DotNet</title>
-        <authors>Charlie Poole, Terje Sandstrom</authors>
-        <license type="expression">MIT</license>
-        <projectUrl>https://docs.nunit.org/articles/vs-test-adapter/Index.html</projectUrl>
-        <repository type="git" url="https://github.com/nunit/nunit3-vs-adapter"/>
-        <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
-        <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <summary>NUnit3 adapter for running tests in Visual Studio and DotNet. Works with NUnit 3.x, use the NUnit 2 adapter for 2.x tests.</summary>
-        <description>
-          The NUnit3 TestAdapter for Visual Studio, all versions from 2012 and onwards, and DotNet (incl. .Net core).
+  <metadata>
+    <id>NUnit3TestAdapter</id>
+    <version>$version$</version>
+    <title>NUnit3 Test Adapter for Visual Studio and DotNet</title>
+    <authors>Charlie Poole, Terje Sandstrom</authors>
+    <license type="expression">MIT</license>
+    <projectUrl>https://docs.nunit.org/articles/vs-test-adapter/Index.html</projectUrl>
+    <repository type="git" url="https://github.com/nunit/nunit3-vs-adapter"/>
+    <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>NUnit3 adapter for running tests in Visual Studio and DotNet. Works with NUnit 3.x, use the NUnit 2 adapter for 2.x tests.</summary>
+    <description>
+      The NUnit3 TestAdapter for Visual Studio, all versions from 2012 and onwards, and DotNet (incl. .Net core).
 
-          Note that this package ONLY contains the adapter, not the NUnit framework.
-          For VS 2017 and forward, you should add this package to every test project in your solution. (Earlier versions only require a single adapter package per solution.)
-        </description>
-        <releaseNotes>See https://docs.nunit.org/articles/vs-test-adapter/Adapter-Release-Notes.html </releaseNotes>
-        <copyright>Copyright (c) 2011-2021 Charlie Poole, 2014-2022 Terje Sandstrom</copyright>
-        <language>en-US</language>
-        <tags>test visualstudio testadapter nunit nunit3 dotnet</tags>
+      Note that this package ONLY contains the adapter, not the NUnit framework.
+      For VS 2017 and forward, you should add this package to every test project in your solution. (Earlier versions only require a single adapter package per solution.)
+    </description>
+    <releaseNotes>See https://docs.nunit.org/articles/vs-test-adapter/Adapter-Release-Notes.html </releaseNotes>
+    <copyright>Copyright (c) 2011-2021 Charlie Poole, 2014-2022 Terje Sandstrom</copyright>
+    <language>en-US</language>
+    <tags>test visualstudio testadapter nunit nunit3 dotnet</tags>
 
-        <developmentDependency>false</developmentDependency>
-    </metadata>
-    <files>
-        <file src="build\net35\NUnit3.TestAdapter.dll" target="build\net35\NUnit3.TestAdapter.dll" />
-        <file src="build\net35\NUnit3.TestAdapter.pdb" target="build\net35\NUnit3.TestAdapter.pdb" />
-        <file src="build\net35\nunit.engine.dll" target="build\net35\nunit.engine.dll" />
-        <file src="build\net35\nunit.engine.api.dll" target="build\net35\nunit.engine.api.dll" />
-        <file src="build\net35\nunit.engine.core.dll" target="build\net35\nunit.engine.core.dll" />
-        <file src="build\net35\testcentric.engine.metadata.dll" target="build\net35\testcentric.engine.metadata.dll"/>
-        <file src="build\net35\NUnit3TestAdapter.props" target="build\net35\NUnit3TestAdapter.props" />
+    <developmentDependency>false</developmentDependency>
+  </metadata>
+  <files>
+    <file src="build\net35\NUnit3.TestAdapter.dll" target="build\net35\NUnit3.TestAdapter.dll" />
+    <file src="build\net35\NUnit3.TestAdapter.pdb" target="build\net35\NUnit3.TestAdapter.pdb" />
+    <file src="build\net35\nunit.engine.dll" target="build\net35\nunit.engine.dll" />
+    <file src="build\net35\nunit.engine.api.dll" target="build\net35\nunit.engine.api.dll" />
+    <file src="build\net35\nunit.engine.core.dll" target="build\net35\nunit.engine.core.dll" />
+    <file src="build\net35\testcentric.engine.metadata.dll" target="build\net35\testcentric.engine.metadata.dll"/>
+    <file src="build\net35\NUnit3TestAdapter.props" target="build\net35\NUnit3TestAdapter.props" />
 
-        <file src="build\netcoreapp2.1\NUnit3.TestAdapter.dll" target="build\netcoreapp2.1\NUnit3.TestAdapter.dll" />
-        <file src="build\netcoreapp2.1\NUnit3.TestAdapter.pdb" target="build\netcoreapp2.1\NUnit3.TestAdapter.pdb" />
-        <file src="build\netcoreapp2.1\nunit.engine.dll" target="build\netcoreapp2.1\nunit.engine.dll" />
-        <file src="build\netcoreapp2.1\nunit.engine.api.dll" target="build\netcoreapp2.1\nunit.engine.api.dll" />
-        <file src="build\netcoreapp2.1\nunit.engine.core.dll" target="build\netcoreapp2.1\nunit.engine.core.dll" />
-        <file src="build\netcoreapp2.1\testcentric.engine.metadata.dll" target="build\netcoreapp2.1\testcentric.engine.metadata.dll"/>
-        <file src="build\netcoreapp2.1\NUnit3TestAdapter.props" target="build\netcoreapp2.1\NUnit3TestAdapter.props" />
-
-    </files>
+    <file src="build\netcoreapp3.1\NUnit3.TestAdapter.dll" target="build\netcoreapp3.1\NUnit3.TestAdapter.dll" />
+    <file src="build\netcoreapp3.1\NUnit3.TestAdapter.pdb" target="build\netcoreapp3.1\NUnit3.TestAdapter.pdb" />
+    <file src="build\netcoreapp3.1\nunit.engine.dll" target="build\netcoreapp3.1\nunit.engine.dll" />
+    <file src="build\netcoreapp3.1\nunit.engine.api.dll" target="build\netcoreapp3.1\nunit.engine.api.dll" />
+    <file src="build\netcoreapp3.1\nunit.engine.core.dll" target="build\netcoreapp3.1\nunit.engine.core.dll" />
+    <file src="build\netcoreapp3.1\testcentric.engine.metadata.dll" target="build\netcoreapp3.1\testcentric.engine.metadata.dll"/>
+    <file src="build\netcoreapp3.1\NUnit3TestAdapter.props" target="build\netcoreapp3.1\NUnit3TestAdapter.props" />
+  </files>
 </package>

--- a/nuget/netcoreapp3.1/NUnit3TestAdapter.props
+++ b/nuget/netcoreapp3.1/NUnit3TestAdapter.props
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.dll">
+      <Link>NUnit3.TestAdapter.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb" Condition="Exists('$(MSBuildThisFileDirectory)NUnit3.TestAdapter.pdb')">
+      <Link>NUnit3.TestAdapter.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)nunit.engine.dll">
+      <Link>nunit.engine.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)nunit.engine.api.dll">
+      <Link>nunit.engine.api.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)nunit.engine.core.dll">
+      <Link>nunit.engine.core.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)testcentric.engine.metadata.dll">
+      <Link>testcentric.engine.metadata.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/NUnit.TestAdapter.Tests.Acceptance/AcceptanceTests.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/AcceptanceTests.cs
@@ -32,12 +32,12 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance
         public static IEnumerable<string> TargetFrameworks => new[]
         {
             LowestNetfxTarget,
-            Frameworks.NetCoreApp21
+            Frameworks.NetCoreApp31
         };
 
         public static IEnumerable<string> DotNetCliTargetFrameworks => new[]
         {
-            Frameworks.NetCoreApp21,
+           // Frameworks.NetCoreApp21,  // Doesnt seem to be supported by VS 2022 anymore
             Frameworks.NetCoreApp31,
             Frameworks.Net50,
             Frameworks.Net60,

--- a/src/NUnit.TestAdapter.Tests.Acceptance/NUnit.TestAdapter.Tests.Acceptance.csproj
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/NUnit.TestAdapter.Tests.Acceptance.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
   </ItemGroup>
 

--- a/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/TestSourceWithCustomNames.cs
@@ -83,8 +83,9 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Acceptance
 
         [Test, Platform("Win")]
         [TestCase("net48")] // test code requires ValueTuple support, so can't got to net35
-        [TestCase("netcoreapp2.1")]
+        [TestCase("netcoreapp3.1")]
         [TestCase("net5.0")]
+        [TestCase("net6.0")]
         public static void Single_target_csproj(string targetFramework)
         {
             var workspace = CreateWorkspace()

--- a/src/NUnit3AdapterExternalTests/NUnit3AdapterExternalTests.csproj
+++ b/src/NUnit3AdapterExternalTests/NUnit3AdapterExternalTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>NUnit.VisualStudio.TestAdapter.ExternalTests</AssemblyName>
     <RootNamespace>NUnit.VisualStudio.TestAdapter.Tests</RootNamespace>
-    <TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -4,9 +4,9 @@
     <AssemblyName>NUnit3.TestAdapter</AssemblyName>
     <!--<AssemblyName>NUnit3.TestAdapterDebug</AssemblyName>-->
     <RootNamespace>NUnit.VisualStudio.TestAdapter</RootNamespace>
-    <!--<TargetFramework>netcoreapp2.1</TargetFramework>-->
+    <!--<TargetFramework>netcoreapp3.1</TargetFramework>-->
     <!-- For testing and debugging-->
-    <TargetFrameworks>net35;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SourceLinkOriginUrl>https://github.com/nunit/nunit3-vs-adapter</SourceLinkOriginUrl>
     <SourceLinkCreate>true</SourceLinkCreate>

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitEngineAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitEngineAdapter.cs
@@ -65,7 +65,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
 #endif
             InternalEngineCreated?.Invoke(engineX);
             TestEngine = engineX;
-            var tmpPath = Path.Combine(Path.GetTempPath(), "NUnit.Engine.Logs");
+            var tmpPath = Path.Combine(Path.GetTempPath(), "NUnit.Engine");
             if (!Directory.Exists(tmpPath))
                 Directory.CreateDirectory(tmpPath);
             TestEngine.WorkDirectory = tmpPath;

--- a/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
+++ b/src/NUnitTestAdapter/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿// ****************************************************************
-// Copyright (c) 2011-2021 Charlie Poole, Terje Sandstrom.
+// Copyright (c) 2011-2021 Charlie Poole, 2014-2022 Terje Sandstrom.
 // ****************************************************************
 
 using System;
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 [assembly: Guid("c0aad5e4-b486-49bc-b3e8-31e01be6fefe")]
-[assembly: AssemblyVersion("4.3.0.0")]
-[assembly: AssemblyFileVersion("4.3.0.0")]
+[assembly: AssemblyVersion("4.3.1.0")]
+[assembly: AssemblyFileVersion("4.3.1.0")]
 
 [assembly: InternalsVisibleTo("NUnit.VisualStudio.TestAdapter.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010029b97dea816272cc4ea44cf3cf666f8150d6dfe1274b6c2e6c4d54259b756888ec08ad6dd3ea0f540b30408b948ae5f39cf0c7b210abdec267b367ce1eccab97d5c6c02ee67090827ffd699544fa2add4849b45a1901eac08495bfee0397fba3946ff3912ce0b9a497818e418a77a0c8db4ca1780e7b6f6dd6911395fcc0faba")]

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -158,6 +158,7 @@ namespace NUnit.VisualStudio.TestAdapter
 #endif
             var assLoc = Assembly.GetExecutingAssembly().Location;
             Debug($"{fw} adapter running from {assLoc}");
+            Debug($"Current directory: {Environment.CurrentDirectory}");
         }
 
         public void InfoNoTests(bool discoveryResultsHasNoNUnitTests, string assemblyPath)

--- a/src/NUnitTestAdapterTests/Fakes/FakeRunSettings.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeRunSettings.cs
@@ -33,7 +33,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes
             throw new NotImplementedException();
         }
 
-        public virtual string SettingsXml => "<RunSettings><NUnit><SkipNonTestAssemblies>false</SkipNonTestAssemblies></NUnit></RunSettings>";
+        public virtual string SettingsXml => "<RunSettings><NUnit><SkipNonTestAssemblies>false</SkipNonTestAssemblies><Verbosity>5</Verbosity></NUnit></RunSettings>";
     }
 
     class FakeRunSettingsForTestOutput : FakeRunSettings

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
   </ItemGroup>
 

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -4,7 +4,7 @@
     <IsTestProject>true</IsTestProject>
     <RootNamespace>NUnit.VisualStudio.TestAdapter.Tests</RootNamespace>
     <AssemblyName>NUnit.VisualStudio.TestAdapter.Tests</AssemblyName>
-    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp3.1</TargetFrameworks>
     <!--<TargetFrameworks>netcoreapp2.1</TargetFrameworks>-->
     <!-- For testing and debugging-->
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -19,13 +19,13 @@
     <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="11.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.3.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnitTestAdapterTests/NUnitEngineTests/NUnitDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEngineTests/NUnitDiscoveryTests.cs
@@ -732,8 +732,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.NUnitEngineTests
 </test-run>";
 
         private const string ExplicitQuickTestXml =
-            @"<test-run id='0' name='NUnit.VisualStudio.TestAdapter.Tests.dll' fullname='D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapterTests\bin\Debug\netcoreapp2.1\NUnit.VisualStudio.TestAdapter.Tests.dll' runstate='Runnable' testcasecount='1'>
-   <test-suite type='Assembly' id='0-1358' name='NUnit.VisualStudio.TestAdapter.Tests.dll' fullname='D:/repos/NUnit/nunit3-vs-adapter/src/NUnitTestAdapterTests/bin/Debug/netcoreapp2.1/NUnit.VisualStudio.TestAdapter.Tests.dll' runstate='Runnable' testcasecount='1'>
+            @"<test-run id='0' name='NUnit.VisualStudio.TestAdapter.Tests.dll' fullname='D:\repos\NUnit\nunit3-vs-adapter\src\NUnitTestAdapterTests\bin\Debug\netcoreapp3.1\NUnit.VisualStudio.TestAdapter.Tests.dll' runstate='Runnable' testcasecount='1'>
+   <test-suite type='Assembly' id='0-1358' name='NUnit.VisualStudio.TestAdapter.Tests.dll' fullname='D:/repos/NUnit/nunit3-vs-adapter/src/NUnitTestAdapterTests/bin/Debug/netcoreapp3.1/NUnit.VisualStudio.TestAdapter.Tests.dll' runstate='Runnable' testcasecount='1'>
       <test-suite type='TestSuite' id='0-1359' name='NUnit' fullname='NUnit' runstate='Runnable' testcasecount='1'>
          <test-suite type='TestSuite' id='0-1360' name='VisualStudio' fullname='NUnit.VisualStudio' runstate='Runnable' testcasecount='1'>
             <test-suite type='TestSuite' id='0-1361' name='TestAdapter' fullname='NUnit.VisualStudio.TestAdapter' runstate='Runnable' testcasecount='1'>

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -42,7 +42,8 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
             yield return new FakeDiscoveryContext(new FakeRunSettings());
         }
     }
-
+    
+    [Ignore("These tests needs to rewritten as isolated tests")]
     [Category("TestDiscovery")]
     public class TestDiscoveryTests : ITestCaseDiscoverySink
     {

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -24,10 +24,13 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
 using NSubstitute;
+
 using NUnit.Framework;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests
@@ -38,11 +41,11 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
     {
         public static IEnumerable<IDiscoveryContext> TestDiscoveryData()
         {
-           // yield return new FakeDiscoveryContext(null);
+            // yield return new FakeDiscoveryContext(null);
             yield return new FakeDiscoveryContext(new FakeRunSettings());
         }
     }
-    
+
     [Ignore("These tests needs to rewritten as isolated tests")]
     [Category("TestDiscovery")]
     public class TestDiscoveryTests : ITestCaseDiscoverySink
@@ -50,7 +53,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         static readonly string MockAssemblyPath =
             Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
 
-        private readonly List<TestCase> testCases = new ();
+        private readonly List<TestCase> testCases = new();
 
         private readonly IDiscoveryContext _context;
 
@@ -135,13 +138,13 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
                 this);
         }
 
-#region ITestCaseDiscoverySink Methods
+        #region ITestCaseDiscoverySink Methods
 
         void ITestCaseDiscoverySink.SendTestCase(TestCase discoveredTest)
         {
         }
 
-#endregion
+        #endregion
     }
 
     [Category("TestDiscovery")]

--- a/src/NUnitTestAdapterTests/TestExecutionTests.cs
+++ b/src/NUnitTestAdapterTests/TestExecutionTests.cs
@@ -62,7 +62,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         }
     }
 
-
+    [Ignore("These tests needs to rewritten as isolated tests")]
     [Category("TestExecution")]
     public class TestFilteringTests
     {
@@ -118,6 +118,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         }
     }
 
+    [Ignore("These tests needs to rewritten as isolated tests")]
     [Category("TestExecution")]
     public class TestExecutionTests
     {

--- a/src/empty-assembly/empty-assembly.csproj
+++ b/src/empty-assembly/empty-assembly.csproj
@@ -4,7 +4,7 @@
     <IsTestProject>false</IsTestProject>
     <AssemblyName>empty-assembly</AssemblyName>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mock-assembly/mock-assembly.csproj
+++ b/src/mock-assembly/mock-assembly.csproj
@@ -4,7 +4,7 @@
     <IsTestProject>false</IsTestProject>
     <AssemblyName>mock-assembly</AssemblyName>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix for issues #1033 #1030 #1028 #1027 #1026 and regression on #987
Remove support for netcoreapp2.1, lowest is netcoreapp3.1
Temporarily ignores in-process assembly tests as they are blocked by NUnit issue https://github.com/nunit/nunit/issues/4255
