### PR TITLE
Enginefix

### DIFF
--- a/NUnit3TestAdapter.sln
+++ b/NUnit3TestAdapter.sln
@@ -62,6 +62,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "netcoreapp3.1", "netcoreapp
 		nuget\netcoreapp3.1\NUnit3TestAdapter.props = nuget\netcoreapp3.1\NUnit3TestAdapter.props
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "images", "images", "{3D1159FD-FC4D-4750-87EA-F477B3912B3C}"
+	ProjectSection(SolutionItems) = preProject
+		images\nunit_256.png = images\nunit_256.png
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +106,7 @@ Global
 		{062B1763-73C8-4B5A-92DF-C66A36C43CE1} = {7CE30108-5D81-4850-BE6B-C8BCA35D3592}
 		{7D708804-B2F1-4A31-A9FB-85A0C7433200} = {062B1763-73C8-4B5A-92DF-C66A36C43CE1}
 		{2F940513-5B8F-45A5-A188-7C5D03D1B50D} = {DE347D88-F6ED-4031-AFC2-318F63E39BC9}
+		{3D1159FD-FC4D-4750-87EA-F477B3912B3C} = {7CE30108-5D81-4850-BE6B-C8BCA35D3592}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8EF03474-188E-44A8-8C76-9FBCF9A382EC}

--- a/build.cake
+++ b/build.cake
@@ -12,8 +12,8 @@ var configuration = Argument("configuration", "Release");
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "4.4.0";
-var modifier = "";
+var version = "4.4.1";
+var modifier = "-alpha.1";
 
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";

--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var configuration = Argument("configuration", "Release");
 //////////////////////////////////////////////////////////////////////
 
 var version = "4.4.1";
-var modifier = "-alpha.1";
+var modifier = "";
 
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";

--- a/nuget.config
+++ b/nuget.config
@@ -2,8 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <!--<add key="Local" value="C:\nuget" />-->
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="Local" value="c:\nuget" />
+    <!--<add key="Local" value="c:\nuget" />-->
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -4,6 +4,6 @@
     <clear />
     <!--<add key="Local" value="C:\nuget" />-->
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <!--<add key="Local" value="c:\nuget" />-->
+    <add key="Local" value="c:\nuget" />
   </packageSources>
 </configuration>

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -8,8 +8,8 @@
     <license type="expression">MIT</license>
     <projectUrl>https://docs.nunit.org/articles/vs-test-adapter/Index.html</projectUrl>
     <repository type="git" url="https://github.com/nunit/nunit3-vs-adapter"/>
-    <icon>images\nunit_256.png</icon>
-    <readme>README.md</readme>
+    <icon>nunit_256.png</icon>
+    <readme>docs\README.md</readme>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>NUnit3 adapter for running tests in Visual Studio and DotNet. Works with NUnit 3.x, use the NUnit 2 adapter for 2.x tests.</summary>
     <description>
@@ -26,8 +26,8 @@
     <developmentDependency>false</developmentDependency>
   </metadata>
   <files>
-    <file src="images\nunit_256.png" target="" />
-    <file src="README.md" target="docs\" />
+    <file src="..\..\images\nunit_256.png" target="" />
+    <file src="..\..\README.md" target="docs\" />
 
     <file src="build\net462\NUnit3.TestAdapter.dll" target="build\net462\NUnit3.TestAdapter.dll" />
     <file src="build\net462\NUnit3.TestAdapter.pdb" target="build\net462\NUnit3.TestAdapter.pdb" />

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -8,11 +8,12 @@
     <license type="expression">MIT</license>
     <projectUrl>https://docs.nunit.org/articles/vs-test-adapter/Index.html</projectUrl>
     <repository type="git" url="https://github.com/nunit/nunit3-vs-adapter"/>
-    <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
+    <icon>images\nunit_256.png</icon>
+    <readme>README.md</readme>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>NUnit3 adapter for running tests in Visual Studio and DotNet. Works with NUnit 3.x, use the NUnit 2 adapter for 2.x tests.</summary>
     <description>
-      The NUnit3 TestAdapter for Visual Studio, all versions from 2012 and onwards, and DotNet (incl. .Net core).
+      The NUnit3 TestAdapter for Visual Studio, all versions from 2012 and onwards, and DotNet (incl. .Net core), versions .net framework 4.6.2 or higher, .net core 3.1, .net 5 or higher.
 
       Note that this package ONLY contains the adapter, not the NUnit framework.
       For VS 2017 and forward, you should add this package to every test project in your solution. (Earlier versions only require a single adapter package per solution.)
@@ -25,6 +26,9 @@
     <developmentDependency>false</developmentDependency>
   </metadata>
   <files>
+    <file src="images\nunit_256.png" target="" />
+    <file src="README.md" target="docs\" />
+
     <file src="build\net462\NUnit3.TestAdapter.dll" target="build\net462\NUnit3.TestAdapter.dll" />
     <file src="build\net462\NUnit3.TestAdapter.pdb" target="build\net462\NUnit3.TestAdapter.pdb" />
     <file src="build\net462\nunit.engine.dll" target="build\net462\nunit.engine.dll" />

--- a/src/NUnit.TestAdapter.Tests.Acceptance/NUnit.TestAdapter.Tests.Acceptance.csproj
+++ b/src/NUnit.TestAdapter.Tests.Acceptance/NUnit.TestAdapter.Tests.Acceptance.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.0-beta.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.0" />
   </ItemGroup>

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
-    <PackageReference Include="nunit.engine" Version="3.16.3" />
+    <PackageReference Include="nunit.engine" Version="3.15.3-net8-3153-1" />
     <PackageReference Include="TestCentric.Metadata" Version="1.7.1" Aliases="TestCentric" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix for issues #1065, #1066, #1069 and #1070

This PR will fail the builds since it uses a non-publish NUnit.Engine package. 
The code for this engine package can be found here:  https://github.com/nunit/nunit-console/tree/release-3.15.3, but note it has not been released yet.  The content however is embedded with the adapter