### PR TITLE
feat: enable custom test output result file

### DIFF
--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -119,6 +119,7 @@ namespace NUnit.VisualStudio.TestAdapter
         public string WorkDirectory { get; private set; }
         public string Where { get; private set; }
         public string TestOutputXml { get; private set; }
+        public string TestOutputXmlFileNameWithoutExtension { get; private set; }
         public bool UseTestOutputXml => !string.IsNullOrEmpty(TestOutputXml) || OutputXmlFolderMode == OutputXmlFolderMode.UseResultDirectory;
 
         public OutputXmlFolderMode OutputXmlFolderMode { get; private set; } = OutputXmlFolderMode.RelativeToWorkFolder;
@@ -329,6 +330,7 @@ namespace NUnit.VisualStudio.TestAdapter
         private void ParseOutputXml(XmlNode nunitNode)
         {
             TestOutputXml = GetInnerTextWithLog(nunitNode, nameof(TestOutputXml));
+            TestOutputXmlFileNameWithoutExtension = GetInnerTextWithLog(nunitNode, nameof(TestOutputXmlFileNameWithoutExtension));
             if (Path.IsPathRooted(TestOutputXml))
             {
                 OutputXmlFolderMode = OutputXmlFolderMode.AsSpecified;

--- a/src/NUnitTestAdapter/IAdapterSettings.cs
+++ b/src/NUnitTestAdapter/IAdapterSettings.cs
@@ -47,6 +47,7 @@ public interface IAdapterSettings
 
     VsTestCategoryType VsTestCategoryType { get; }
     string TestOutputXml { get; }
+    string TestOutputXmlFileNameWithoutExtension { get; }
     bool UseTestOutputXml { get; }
     OutputXmlFolderMode OutputXmlFolderMode { get; }
 

--- a/src/NUnitTestAdapter/NUnitEngine/NUnitEngineAdapter.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/NUnitEngineAdapter.cs
@@ -163,7 +163,7 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             if (!settings.UseTestOutputXml)
                 return;
 
-            string path = GetXmlFilePath(testOutputXmlFolder, Path.GetFileNameWithoutExtension(assemblyPath), "xml");
+            string path = GetXmlFilePath(testOutputXmlFolder, GetTestOutputFileName(assemblyPath), "xml");
             var resultService = GetService<IResultService>();
 
             // Following null argument should work for nunit3 format. Empty array is OK as well.
@@ -171,6 +171,15 @@ namespace NUnit.VisualStudio.TestAdapter.NUnitEngine
             var resultWriter = resultService.GetResultWriter("nunit3", null);
             resultWriter.WriteResultFile(testResults.FullTopNode, path);
             logger.Info($"   Test results written to {path}");
+        }
+
+        public string GetTestOutputFileName(string assemblyPath)
+        {
+            if (string.IsNullOrWhiteSpace(settings.TestOutputXmlFileNameWithoutExtension))
+            {
+                return Path.GetFileNameWithoutExtension(assemblyPath);
+            }
+            return settings.TestOutputXmlFileNameWithoutExtension;
         }
 
         public string GetXmlFilePath(string folder, string defaultFileName, string extension)

--- a/src/NUnitTestAdapterTests/NUnitEngineTests/NUnitEngineAdapterTests.cs
+++ b/src/NUnitTestAdapterTests/NUnitEngineTests/NUnitEngineAdapterTests.cs
@@ -19,6 +19,19 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.NUnitEngineTests
             Assert.That(path, Is.EqualTo("c:/assembly.xml"));
         }
 
+        [TestCase("", "myAssemblyFilename")]
+        [TestCase("<TestOutputXmlFileNameWithoutExtension>whateverFileName</TestOutputXmlFileNameWithoutExtension>", "whateverFileName")]
+        public void When_setting_up_defined_result_GetTestOutputFileName_returns_defined_filename(string testOutputXmlFileNameWithoutExtensionXmlNode, string expectedFileName)
+        {
+            var logger = Substitute.For<ITestLogger>();
+            var settings = new AdapterSettings(logger);
+            settings.Load($@"<RunSettings><NUnit><WorkDirectory>c:\whatever</WorkDirectory><TestOutputXml>/my/work/dir</TestOutputXml>{testOutputXmlFileNameWithoutExtensionXmlNode}</NUnit></RunSettings>");
+            var sut = new NUnitEngineAdapter();
+            sut.InitializeSettingsAndLogging(settings, logger);
+            string filename = sut.GetTestOutputFileName("c:/myAssemblyFilename.dll");
+            Assert.That(filename, Is.EqualTo(expectedFileName));
+        }
+
         [Test]
         public void TestXmlFileNameGenerationNewOutputXmlFileForEachRun()
         {


### PR DESCRIPTION
When using the ``TestOutputXmlFileNameWithoutExtension`` run setting property, the client can define a custom result file name rather than the name of the assembly to be tested