### PR TITLE
Fix NUnit extension version

### DIFF
--- a/src/NUnitTestAdapter/TestingPlatformAdapter/NUnitExtension.cs
+++ b/src/NUnitTestAdapter/TestingPlatformAdapter/NUnitExtension.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Reflection;
+using System.Threading.Tasks;
 
 using Microsoft.Testing.Platform.Extensions;
 
@@ -10,11 +11,18 @@ namespace NUnit.VisualStudio.TestAdapter.TestingPlatformAdapter
 
         public string DisplayName => "NUnit";
 
-        // TODO: Decide whether to read from assembly or use hardcoded string.
-        public string Version => "4.5.0";
+        public string Version { get; } = GetAssemblyVersion();
 
         public string Description => "NUnit adapter for Microsoft Testing Platform";
 
         public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+        private static string GetAssemblyVersion()
+        {
+            var assembly = typeof(NUnitExtension).Assembly;
+            var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? assembly.GetName().Version?.ToString();
+            return version;
+        }
     }
 }


### PR DESCRIPTION
Use AssemblyInformationalVersionAttribute version or fallback to
AssemblyVersion instead of using hardcoded version.