### PR TITLE
Exclude the partition filter from test expansion

### DIFF
--- a/src/NUnitTestAdapter/Execution.cs
+++ b/src/NUnitTestAdapter/Execution.cs
@@ -80,6 +80,10 @@ public abstract class Execution(IExecutionContext ctx)
             }
             return testFilter;
         }
+        if (testFilter.IsPartitionFilter())
+        {
+            return testFilter;
+        }
         var filterBuilder = CreateTestFilterBuilder();
         return filterBuilder.FilterByList(discovery.LoadedTestCases);
     }

--- a/src/NUnitTestAdapter/NUnitEngine/Extensions.cs
+++ b/src/NUnitTestAdapter/NUnitEngine/Extensions.cs
@@ -43,6 +43,9 @@ public static class Extensions
     public static bool IsCategoryFilter(this TestFilter filter) =>
         filter != TestFilter.Empty && filter.Text.Contains("<cat>");
 
+    public static bool IsPartitionFilter(this TestFilter filter) =>
+        filter != TestFilter.Empty && filter.Text.Contains("<partition>");
+
     public static bool IsNegativeCategoryFilter(this TestFilter filter) =>
         filter.IsCategoryFilter() && filter.Text.Contains("<not><cat>");
 }


### PR DESCRIPTION
Addressing my comment here https://github.com/nunit/nunit3-vs-adapter/issues/1138#issuecomment-2116067823

I saw the category filter doing this already and copied its approach. Please let me know if there is another approach you think I should take 