### PR TITLE
Bump Microsoft.Testing.* versions in nuspec

### DIFF
--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -27,12 +27,12 @@
 
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="1.2.1" />
-        <dependency id="Microsoft.Testing.Platform.MSBuild" version="1.2.1" />
+        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="1.3.1" />
+        <dependency id="Microsoft.Testing.Platform.MSBuild" version="1.3.1" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="1.2.1" />
-        <dependency id="Microsoft.Testing.Platform.MSBuild" version="1.2.1" />
+        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="1.3.1" />
+        <dependency id="Microsoft.Testing.Platform.MSBuild" version="1.3.1" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Follow-up from #1199, issue spotted by @nbalu in https://github.com/nunit/nunit3-vs-adapter/commit/359a242fbe6de0d2bb36ecd5a6d382d734218ffd#r144895782