### PR TITLE
Set generate self-registered extensions property to default value

### DIFF
--- a/nuget/netcoreapp3.1/NUnit3TestAdapter.targets
+++ b/nuget/netcoreapp3.1/NUnit3TestAdapter.targets
@@ -4,6 +4,7 @@
   <!-- Handle the coexistance between Microsoft.Testing.Platform and Microsoft.NET.Test.Sdk  -->
   <PropertyGroup>
     <GenerateTestingPlatformEntryPoint Condition=" '$(GenerateTestingPlatformEntryPoint)' == '' ">$(EnableNUnitRunner)</GenerateTestingPlatformEntryPoint>
+    <GenerateSelfRegisteredExtensions Condition=" '$(GenerateSelfRegisteredExtensions)' == '' ">$(EnableNUnitRunner)</GenerateSelfRegisteredExtensions>
     <GenerateProgramFile Condition=" '$(EnableNUnitRunner)' == 'true' ">false</GenerateProgramFile>
   </PropertyGroup>   
     


### PR DESCRIPTION
This is a fix for 

 ```
  S:\c\nunit3-vs-adapter.issues\Issue1152\2-nunit-runner-dotnet-test\obj\Debug\net6.0\TestPlatformEntryPoint.cs(13,9): 
error CS0103: The name 'SelfRegisteredExtensions' does not exist in the current context
```

We need to revisit how we use the IsTestingPlatformApplication property so you can use just that to enable / disable all features.