### PR TITLE
Disable TestingPlatform server mode when runner is not active

### DIFF
--- a/nuget/net462/NUnit3TestAdapter.targets
+++ b/nuget/net462/NUnit3TestAdapter.targets
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <GenerateTestingPlatformEntryPoint Condition=" '$(GenerateTestingPlatformEntryPoint)' == '' ">$(EnableNUnitRunner)</GenerateTestingPlatformEntryPoint>
     <GenerateSelfRegisteredExtensions Condition=" '$(GenerateSelfRegisteredExtensions)' == '' ">$(EnableNUnitRunner)</GenerateSelfRegisteredExtensions>
+    <DisableTestingPlatformServerCapability Condition=" '$(EnableNUnitRunner)' == 'false' or '$(EnableNUnitRunner)' == '' " >true</DisableTestingPlatformServerCapability>
     <GenerateProgramFile Condition=" '$(EnableNUnitRunner)' == 'true' ">false</GenerateProgramFile>
   </PropertyGroup>   
     

--- a/nuget/netcoreapp3.1/NUnit3TestAdapter.targets
+++ b/nuget/netcoreapp3.1/NUnit3TestAdapter.targets
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <GenerateTestingPlatformEntryPoint Condition=" '$(GenerateTestingPlatformEntryPoint)' == '' ">$(EnableNUnitRunner)</GenerateTestingPlatformEntryPoint>
     <GenerateSelfRegisteredExtensions Condition=" '$(GenerateSelfRegisteredExtensions)' == '' ">$(EnableNUnitRunner)</GenerateSelfRegisteredExtensions>
+    <DisableTestingPlatformServerCapability Condition=" '$(EnableNUnitRunner)' == 'false' or '$(EnableNUnitRunner)' == '' " >true</DisableTestingPlatformServerCapability>
     <GenerateProgramFile Condition=" '$(EnableNUnitRunner)' == 'true' ">false</GenerateProgramFile>
   </PropertyGroup>   
     


### PR DESCRIPTION
Disable server capability, so when NUnitRunner is disabled, VisualStudio (and VSCode) is falling back to VSTest instead of trying to start the exe as testing platform test project.