### PR TITLE
Fixes #1248, Allowing to exclude stacktrace in output.

### DIFF
--- a/src/NUnitTestAdapter/AdapterSettings.cs
+++ b/src/NUnitTestAdapter/AdapterSettings.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2014-2021 Charlie Poole, 2014-2022 Terje Sandstrom
+// Copyright (c) 2014-2021 Charlie Poole, 2014-2025 Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -158,6 +158,8 @@ public class AdapterSettings(ITestLogger logger) : IAdapterSettings
     public bool UseNUnitFilter { get; private set; }
     public bool IncludeStackTraceForSuites { get; private set; }
 
+    public bool IncludeStackTrace { get; private set; }
+
     public VsTestCategoryType VsTestCategoryType { get; private set; } = VsTestCategoryType.NUnit;
 
     /// <summary>
@@ -256,6 +258,7 @@ public class AdapterSettings(ITestLogger logger) : IAdapterSettings
         StopOnError = GetInnerTextAsBool(nunitNode, nameof(StopOnError), false);
         UseNUnitFilter = GetInnerTextAsBool(nunitNode, nameof(UseNUnitFilter), true);
         IncludeStackTraceForSuites = GetInnerTextAsBool(nunitNode, nameof(IncludeStackTraceForSuites), true);
+        IncludeStackTrace = GetInnerTextAsBool(nunitNode, nameof(IncludeStackTrace), true);
         EnsureAttachmentFileScheme = GetInnerTextAsBool(nunitNode, nameof(EnsureAttachmentFileScheme), false);
         SkipExecutionWhenNoTests = GetInnerTextAsBool(nunitNode, nameof(SkipExecutionWhenNoTests), false);
         ThrowOnEachFailureUnderDebugger = GetInnerTextAsBool(nunitNode, nameof(ThrowOnEachFailureUnderDebugger), false);

--- a/src/NUnitTestAdapter/IAdapterSettings.cs
+++ b/src/NUnitTestAdapter/IAdapterSettings.cs
@@ -97,8 +97,7 @@ public interface IAdapterSettings
 
     bool UseNUnitFilter { get; }
     bool IncludeStackTraceForSuites { get; }
-
-
+    bool IncludeStackTrace { get;  }
     void Load(IDiscoveryContext context, TestLogger testLogger = null);
     void Load(string settingsXml);
     void SaveRandomSeed(string dirname);

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -10,11 +10,11 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <SourceLinkOriginUrl>https://github.com/nunit/nunit3-vs-adapter</SourceLinkOriginUrl>
     <SourceLinkCreate>true</SourceLinkCreate>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.0.0.0</FileVersion>
+    <AssemblyVersion>5.1.0.0</AssemblyVersion>
+    <FileVersion>5.1.0.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Title>NUnit3 Test Adapter for Visual Studio</Title>
-    <Copyright>Copyright © 2011-2021 Charlie Poole, 2014-2024 Terje Sandstrom</Copyright>
+    <Copyright>Copyright © 2011-2021 Charlie Poole, 2014-2025 Terje Sandstrom</Copyright>
     <Description>A package containing the NUnit3 TestAdapter for Visual Studio 2012 onwards.
         The package works with Visual Studio 2012 and newer, dotnet test and VSTest.Console.</Description>
     <Company>NUnit Project</Company>

--- a/src/NUnitTestAdapter/NUnitEventListener.cs
+++ b/src/NUnitTestAdapter/NUnitEventListener.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2011-2021 Charlie Poole, Terje Sandstrom
+// Copyright (c) 2011-2021 Charlie Poole, 2014-2025 Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/src/NUnitTestAdapter/TestConverter.cs
+++ b/src/NUnitTestAdapter/TestConverter.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2011-2021 Charlie Poole, 2011 - 2022 Terje Sandstrom
+// Copyright (c) 2011-2021 Charlie Poole, 2011 - 2025 Terje Sandstrom
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -111,7 +111,8 @@ public sealed class TestConverter : IDisposable, ITestConverter
                 case TestOutcome.NotFound:
                     {
                         testCaseResult.ErrorMessage = resultNode.Failure?.Message;
-                        testCaseResult.ErrorStackTrace = resultNode.FailureStackTrace;
+                        if (adapterSettings.IncludeStackTrace)
+                            testCaseResult.ErrorStackTrace = resultNode.FailureStackTrace;
                         break;
                     }
                 case TestOutcome.Skipped:


### PR DESCRIPTION
Fixes #1248, Allowing to exclude stacktrace in output.

Adding runsettings IncludeStackTrace, default true.