### PR TITLE
Report skip reason

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var configuration = Argument("configuration", "Release");
 //////////////////////////////////////////////////////////////////////
 
 
-var version = "5.0.0";
+var version = "5.0.1";
 
 var modifier = "";
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell ./build.ps1 %CAKE_ARGS% %*
+powershell -executionPolicy bypass ./build.ps1 %CAKE_ARGS% %*

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -103,15 +103,7 @@ public sealed class NUnit3TestDiscoverer : NUnitTestAdapter, ITestDiscoverer
                 }
                 else
                 {
-                    if (results.HasNoNUnitTests)
-                    {
-                        if (Settings.Verbosity > 0)
-                            TestLog.Info("Assembly contains no NUnit 3.0 tests: " + sourceAssembly);
-                    }
-                    else
-                    {
-                        TestLog.Info("NUnit failed to load " + sourceAssembly);
-                    }
+                    TestLog.InfoNoRunnableTests(results, sourceAssembly);
                 }
             }
             catch (NUnitEngineException e)

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -306,9 +306,9 @@ public sealed class NUnit3TestExecutor : NUnitTestAdapter, ITestExecutor, IDispo
             TestLog.DebugRunfrom();
             // var discoveryResults = RunType == RunType.CommandLineCurrentNUnit ? null : NUnitEngineAdapter.Explore(filter);
             var discoveryResults = NUnitEngineAdapter.Explore(filter);
-            Dump?.AddString(discoveryResults?.AsString() ?? " No discovery");
+            Dump?.AddString(discoveryResults.AsString());
 
-            if (discoveryResults?.IsRunnable ?? true)
+            if (discoveryResults.IsRunnable)
             {
                 var discovery = new DiscoveryConverter(TestLog, Settings);
                 discovery.Convert(discoveryResults, assemblyPath);
@@ -319,12 +319,12 @@ public sealed class NUnit3TestExecutor : NUnitTestAdapter, ITestExecutor, IDispo
                 }
                 else
                 {
-                    TestLog.InfoNoTests(assemblyPath);
+                    TestLog.InfoNoRunnableTests(discoveryResults, assemblyPath);
                 }
             }
             else
             {
-                TestLog.InfoNoTests(discoveryResults.HasNoNUnitTests, assemblyPath);
+                TestLog.InfoNoRunnableTests(discoveryResults, assemblyPath);
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException || ex.InnerException is BadImageFormatException)

--- a/src/NUnitTestAdapter/TestLogger.cs
+++ b/src/NUnitTestAdapter/TestLogger.cs
@@ -26,6 +26,8 @@ using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
+using NUnit.VisualStudio.TestAdapter.NUnitEngine;
+
 namespace NUnit.VisualStudio.TestAdapter;
 
 public interface ITestLogger
@@ -146,11 +148,12 @@ public class TestLogger(IMessageLogger messageLogger) : IMessageLogger, ITestLog
         Debug($"Current directory: {Environment.CurrentDirectory}");
     }
 
-    public void InfoNoTests(bool discoveryResultsHasNoNUnitTests, string assemblyPath)
+    public void InfoNoRunnableTests(NUnitResults results, string assemblyPath)
     {
-        Info(discoveryResultsHasNoNUnitTests
-            ? "   NUnit couldn't find any tests in " + assemblyPath
-            : "   NUnit failed to load " + assemblyPath);
+        string reason = results.SkipReason() ?? "Failed to load";
+        Info(results.TestCaseCount > 0 ?
+            $"   NUnit couldn't run the {results.TestCaseCount} discovered tests: {reason}" :
+            $"   NUnit couldn't find any tests in {assemblyPath}");
     }
 
     public void InfoNoTests(string assemblyPath)


### PR DESCRIPTION
Fixes #1244 

Change error message if tests are Skipped.

Instead of showing:
   NUnit failed to load D:\Development\Playground\WindowsVersion\bin\Debug\net9.0\WindowsVersion.dll

It now will show:
   NUnit couldn't run the 6 discovered tests: Only supported on Windows10.0.26100.0

Note that `dotnet test` still says: `No test is available` with the additional message indicating some error:
```text
Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.
```

The only way to remove that is to actually run the tests.

But the NUnit engine seems to want to run every test, even though the suite and/or fixture is marked as `Skipped`.

If running the suite, I get messages for every test:
```text
BuildVersionIsAtLeast22000: OneTimeSetUp: Only supported on Windows10.0.26100.0
BuildVersionIsAtLeast26100: OneTimeSetUp: Only supported on Windows10.0.26100.0
MajorVersionIsAtLeast10: OneTimeSetUp: Only supported on Windows10.0.26100.0
Skipped: OneTimeSetUp: Only supported on Windows10.0.26100.0
MajorVersionIsAtLeast10: OneTimeSetUp: Only supported on Windows10.0.26100.0
```

Even though `CompositeWorkItem.PerformWork` seems to indicate otherwise.

I was hoping to get only 1 message if the Suite is non-runnable or one for every Fixture that is Skipped.

That code is in another repository.
