### PR TITLE
Update MTP to 1.6.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Castle.Core" Version="5.1.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="1.5.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="1.6.3" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="NUnit.Analyzers" Version="4.6.0">

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -27,12 +27,12 @@
 
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="1.5.3" />
-        <dependency id="Microsoft.Testing.Platform.MSBuild" version="1.5.3" />
+        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="1.6.3" />
+        <dependency id="Microsoft.Testing.Platform.MSBuild" version="1.6.3" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="1.5.3" />
-        <dependency id="Microsoft.Testing.Platform.MSBuild" version="1.5.3" />
+        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="1.6.3" />
+        <dependency id="Microsoft.Testing.Platform.MSBuild" version="1.6.3" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This release fixes a bug where `IsTestingPlatformApplication` wasn't very reliable (https://github.com/microsoft/testfx/pull/5219). https://github.com/microsoft/testfx/issues/4307