### PR TITLE
Fix MTP not working in IDEs due to IsTestingPlatformApplication not set to true

### DIFF
--- a/nuget/net462/NUnit3TestAdapter.props
+++ b/nuget/net462/NUnit3TestAdapter.props
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <EnableNUnitRunner Condition=" '$(EnableNUnitRunner)' == '' ">false</EnableNUnitRunner>
-    <IsTestingPlatformApplication>$(EnableNUnitRunner)</IsTestingPlatformApplication>
-  </PropertyGroup>
-
   <ItemGroup>
     <!--
       !!! IMPORTANT !!!

--- a/nuget/net462/NUnit3TestAdapter.targets
+++ b/nuget/net462/NUnit3TestAdapter.targets
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Handle the coexistance between Microsoft.Testing.Platform and Microsoft.NET.Test.Sdk  -->
+  <!-- Handle the coexistence between Microsoft.Testing.Platform and Microsoft.NET.Test.Sdk  -->
   <PropertyGroup>
-    <GenerateTestingPlatformEntryPoint Condition=" '$(GenerateTestingPlatformEntryPoint)' == '' ">$(EnableNUnitRunner)</GenerateTestingPlatformEntryPoint>
-    <GenerateSelfRegisteredExtensions Condition=" '$(GenerateSelfRegisteredExtensions)' == '' ">$(EnableNUnitRunner)</GenerateSelfRegisteredExtensions>
-    <DisableTestingPlatformServerCapability Condition=" '$(EnableNUnitRunner)' == 'false' or '$(EnableNUnitRunner)' == '' " >true</DisableTestingPlatformServerCapability>
+    <EnableNUnitRunner Condition=" '$(EnableNUnitRunner)' == '' ">false</EnableNUnitRunner>
+    <IsTestingPlatformApplication>$(EnableNUnitRunner)</IsTestingPlatformApplication>
+
     <GenerateProgramFile Condition=" '$(EnableNUnitRunner)' == 'true' ">false</GenerateProgramFile>
-  </PropertyGroup>   
+  </PropertyGroup>
     
   <Choose>
     <!-- Avoid false warning about missing reference (msbuild bug) -->

--- a/nuget/netcoreapp3.1/NUnit3TestAdapter.props
+++ b/nuget/netcoreapp3.1/NUnit3TestAdapter.props
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    
-  <PropertyGroup>
-    <EnableNUnitRunner Condition=" '$(EnableNUnitRunner)' == '' ">false</EnableNUnitRunner>
-    <IsTestingPlatformApplication>$(EnableNUnitRunner)</IsTestingPlatformApplication>
-  </PropertyGroup>
 
   <ItemGroup>
     <!--

--- a/nuget/netcoreapp3.1/NUnit3TestAdapter.targets
+++ b/nuget/netcoreapp3.1/NUnit3TestAdapter.targets
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Handle the coexistance between Microsoft.Testing.Platform and Microsoft.NET.Test.Sdk  -->
+  <!-- Handle the coexistence between Microsoft.Testing.Platform and Microsoft.NET.Test.Sdk  -->
   <PropertyGroup>
-    <GenerateTestingPlatformEntryPoint Condition=" '$(GenerateTestingPlatformEntryPoint)' == '' ">$(EnableNUnitRunner)</GenerateTestingPlatformEntryPoint>
-    <GenerateSelfRegisteredExtensions Condition=" '$(GenerateSelfRegisteredExtensions)' == '' ">$(EnableNUnitRunner)</GenerateSelfRegisteredExtensions>
-    <DisableTestingPlatformServerCapability Condition=" '$(EnableNUnitRunner)' == 'false' or '$(EnableNUnitRunner)' == '' " >true</DisableTestingPlatformServerCapability>
+    <EnableNUnitRunner Condition=" '$(EnableNUnitRunner)' == '' ">false</EnableNUnitRunner>
+    <IsTestingPlatformApplication>$(EnableNUnitRunner)</IsTestingPlatformApplication>
+
     <GenerateProgramFile Condition=" '$(EnableNUnitRunner)' == 'true' ">false</GenerateProgramFile>
-  </PropertyGroup>   
+  </PropertyGroup>
     
   <Choose>
     <!-- Avoid false warning about missing reference (msbuild bug) -->


### PR DESCRIPTION
It's **too early** to read `EnableNUnitRunner` in props. So, the current code will cause `IsTestingPlatformApplication` to be false, thus disabling server capability, and breaking in IDEs.