### PR TITLE
Rename Tokenizer double character symbols field

### DIFF
--- a/src/NUnitTestAdapter/TestFilterConverter/Tokenizer.cs
+++ b/src/NUnitTestAdapter/TestFilterConverter/Tokenizer.cs
@@ -95,7 +95,7 @@ public class Tokenizer
 
     private const char EOF_CHAR = '\0';
     private const string WORD_BREAK_CHARS = "=~!()&|";
-    private readonly string[] dOubleCharSymbols = { "!=", "!~" };
+    private readonly string[] doubleCharSymbols = { "!=", "!~" };
 
     private Token lookahead;
 
@@ -148,7 +148,7 @@ public class Tokenizer
             // Could be alone or start of a double char symbol
             case '!':
                 GetChar();
-                foreach (string dbl in dOubleCharSymbols)
+                foreach (string dbl in doubleCharSymbols)
                 {
                     if (ch != dbl[0] || NextChar != dbl[1])
                         continue;


### PR DESCRIPTION
## Summary
- rename `dOubleCharSymbols` field to `doubleCharSymbols`
- update references in Tokenizer constructor and foreach loop

## Testing
- `dotnet build NUnit3TestAdapter.sln -c Release` *(fails: `dotnet` not found)*