### PR TITLE
Fix TimingLogger restart logic

### DIFF
--- a/src/NUnitTestAdapter/Internal/TimingLogger.cs
+++ b/src/NUnitTestAdapter/Internal/TimingLogger.cs
@@ -19,9 +19,9 @@ public class TimingLogger
 
     public TimingLogger ReStart()
     {
-        if (settings.Verbosity < 5)
+        if (settings.Verbosity < 5 || Stopwatch == null)
             return this;
-        Stopwatch.StartNew();
+        Stopwatch.Restart();
         return this;
     }
 

--- a/src/NUnitTestAdapterTests/TimingLoggerTests.cs
+++ b/src/NUnitTestAdapterTests/TimingLoggerTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading;
+using NSubstitute;
+using NUnit.Framework;
+using NUnit.VisualStudio.TestAdapter;
+using NUnit.VisualStudio.TestAdapter.Internal;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests;
+
+public class TimingLoggerTests
+{
+    [Test]
+    public void ReStart_ResetsElapsedTime()
+    {
+        var settings = Substitute.For<IAdapterSettings>();
+        settings.Verbosity.Returns(5);
+        var logger = Substitute.For<ITestLogger>();
+
+        var sut = new TimingLogger(settings, logger);
+
+        Thread.Sleep(10);
+        var before = sut.Stopwatch.Elapsed;
+        sut.ReStart();
+        Thread.Sleep(1);
+        var after = sut.Stopwatch.Elapsed;
+
+        Assert.That(before, Is.GreaterThan(TimeSpan.Zero));
+        Assert.That(after, Is.LessThan(before));
+    }
+}
+


### PR DESCRIPTION
## Summary
- fix `TimingLogger.ReStart` so it resets the existing stopwatch
- add test to verify restart behaviour

## Testing
- `dotnet test --no-build` *(fails: command not found)*