### PR TITLE
Add parser for extracting fully qualified names from filter strings

### DIFF
--- a/src/NUnitTestAdapter/TestFilterConverter/FullyQualifiedNameFilterParser.cs
+++ b/src/NUnitTestAdapter/TestFilterConverter/FullyQualifiedNameFilterParser.cs
@@ -39,26 +39,26 @@ public static class FullyQualifiedNameFilterParser
     /// </summary>
     /// <param name="filterString">The raw filter string provided by the test platform.</param>
     /// <returns>A read-only list of the fully qualified names contained in the filter.</returns>
-    public static IReadOnlyList<string> GetFullyQualifiedNames(string? filterString)
+    public static IReadOnlyList<string> GetFullyQualifiedNames(string filterString)
     {
         if (string.IsNullOrWhiteSpace(filterString))
-            return Array.Empty<string>();
+            return [];
 
         var trimmed = filterString.Trim();
 
         if (trimmed.Length == 0)
-            return Array.Empty<string>();
+            return [];
 
-        if (trimmed[0] == '(' && trimmed[^1] == ')' && trimmed.Length > 1)
+        if (trimmed[0] == '(' && trimmed[trimmed.Length - 1] == ')' && trimmed.Length > 1)
             trimmed = trimmed.Substring(1, trimmed.Length - 2);
 
         if (trimmed.Length == 0)
-            return Array.Empty<string>();
+            return [];
 
-        var segments = trimmed.Split(new[] { "|" + FullyQualifiedNamePrefix }, StringSplitOptions.None);
+        var segments = trimmed.Split(["|" + FullyQualifiedNamePrefix], StringSplitOptions.None);
 
         if (segments.Length == 0)
-            return Array.Empty<string>();
+            return [];
 
         var result = new List<string>(segments.Length);
 

--- a/src/NUnitTestAdapterTests/TestFilterConverterTests/FullyQualifiedNameFilterParserTests.cs
+++ b/src/NUnitTestAdapterTests/TestFilterConverterTests/FullyQualifiedNameFilterParserTests.cs
@@ -60,7 +60,7 @@ public class FullyQualifiedNameFilterParserTests
     [TestCase(null)]
     [TestCase("")]
     [TestCase("   ")]
-    public void Should_return_empty_collection_when_filter_is_missing(string? filter)
+    public void Should_return_empty_collection_when_filter_is_missing(string filter)
     {
         var result = FullyQualifiedNameFilterParser.GetFullyQualifiedNames(filter);
 


### PR DESCRIPTION
## Summary
- add a parser that extracts fully qualified test names from vstest filter strings
- cover the new parser with tests including the complex Microsoft testhost filter example

## Testing
- dotnet test NUnit3TestAdapter.sln --no-build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68f93d6d278883218b46368a40dc05e8