### PR TITLE
Added filter for discovery liststest

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet clean:*)",
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)",
+      "WebSearch",
+      "WebFetch(domain:github.com)",
+      "Bash(dotnet run:*)",
+      "Bash(./nunit-test.exe:*)",
+      "Bash(dotnet nunit-test.dll:*)",
+      "Bash(echo:*)",
+      "Bash(dotnet exec:*)",
+      "Bash(cat:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,17 +1,2 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(dotnet clean:*)",
-      "Bash(dotnet build:*)",
-      "Bash(dotnet test:*)",
-      "WebSearch",
-      "WebFetch(domain:github.com)",
-      "Bash(dotnet run:*)",
-      "Bash(./nunit-test.exe:*)",
-      "Bash(dotnet nunit-test.dll:*)",
-      "Bash(echo:*)",
-      "Bash(dotnet exec:*)",
-      "Bash(cat:*)"
-    ]
-  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,4 @@ MigrationBackup/
 .ionide/
 /dupl.xml
 NDependOut/
+.nuget/

--- a/build.cake
+++ b/build.cake
@@ -15,7 +15,7 @@ var configuration = Argument("configuration", "Release");
 
 var version = "6.1.1";
 
-var modifier = "-alpha.49";
+var modifier = "-alpha.51";
 
 var dbgSuffix = configuration.ToLower() == "debug" ? "-dbg" : "";
 var packageVersion = version + modifier + dbgSuffix;

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -178,22 +178,11 @@ public sealed class NUnit3TestDiscoverer : NUnitTestAdapter, ITestDiscoverer
         if (discoveryContext == null)
             return null;
 
-        try
-        {
-            // Use reflection-based filter that works with IDiscoveryContext
-            // (GetTestCaseFilter exists on concrete type but not exposed via interface)
-            var filter = new VsTestFilterForDiscovery(discoveryContext);
-            if (!filter.IsEmpty)
-            {
-                return filter;
-            }
-        }
-        catch
-        {
-            // If filter creation fails, continue without filtering
-        }
-
-        return null;
+        // Use reflection-based filter that works with IDiscoveryContext
+        // (GetTestCaseFilter exists on concrete type but not exposed via interface).
+        // Exceptions from reflection are caught and logged inside VsTestFilterForDiscovery.
+        var filter = new VsTestFilterForDiscovery(discoveryContext, TestLog);
+        return filter.IsEmpty ? null : filter;
     }
 
     private int ProcessTestCases(NUnitResults results, ITestCaseDiscoverySink discoverySink, TestConverterForXml testConverterForXml, IVsTestFilter filter = null)

--- a/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
+++ b/src/NUnitTestAdapter/NUnit3TestDiscoverer.cs
@@ -61,6 +61,9 @@ public sealed class NUnit3TestDiscoverer : NUnitTestAdapter, ITestDiscoverer
         // Ensure any channels registered by other adapters are unregistered
         CleanUpRegisteredChannels();
 
+        // Try to get filter for --list-tests scenario
+        var vsTestFilter = TryCreateDiscoveryFilter(discoveryContext);
+
         if (Settings.InProcDataCollectorsAvailable && sources.Count() > 1)
         {
             TestLog.Error("Unexpected to discover tests in multiple assemblies when InProcDataCollectors specified in run configuration.");
@@ -90,7 +93,7 @@ public sealed class NUnit3TestDiscoverer : NUnitTestAdapter, ITestDiscoverer
                     using (var testConverter = new TestConverterForXml(TestLog, sourceAssemblyPath, Settings))
                     {
                         var timing = new TimingLogger(Settings, TestLog);
-                        cases = ProcessTestCases(results, discoverySink, testConverter);
+                        cases = ProcessTestCases(results, discoverySink, testConverter, vsTestFilter);
                         timing.LogTime("Discovery/Processing/Converting:");
                     }
 
@@ -170,21 +173,58 @@ public sealed class NUnit3TestDiscoverer : NUnitTestAdapter, ITestDiscoverer
 
     #region Helper Methods
 
-    private int ProcessTestCases(NUnitResults results, ITestCaseDiscoverySink discoverySink, TestConverterForXml testConverterForXml)
+    private IVsTestFilter TryCreateDiscoveryFilter(IDiscoveryContext discoveryContext)
     {
-        int cases = 0;
+        if (discoveryContext == null)
+            return null;
+
+        try
+        {
+            // Use reflection-based filter that works with IDiscoveryContext
+            // (GetTestCaseFilter exists on concrete type but not exposed via interface)
+            var filter = new VsTestFilterForDiscovery(discoveryContext);
+            if (!filter.IsEmpty)
+            {
+                return filter;
+            }
+        }
+        catch
+        {
+            // If filter creation fails, continue without filtering
+        }
+
+        return null;
+    }
+
+    private int ProcessTestCases(NUnitResults results, ITestCaseDiscoverySink discoverySink, TestConverterForXml testConverterForXml, IVsTestFilter filter = null)
+    {
+        var testCases = new List<TestCase>();
+
+        // First, convert all test cases
         foreach (XmlNode testNode in results.TestCases())
         {
             try
             {
                 var testCase = testConverterForXml.ConvertTestCase(new NUnitEventTestCase(testNode));
-                discoverySink.SendTestCase(testCase);
-                cases += 1;
+                testCases.Add(testCase);
             }
             catch (Exception ex)
             {
                 TestLog.Warning("Exception converting " + testNode.GetAttribute("fullname"), ex);
             }
+        }
+
+        // Apply filter if present (for --list-tests --filter scenario)
+        IEnumerable<TestCase> filteredCases = filter != null && !filter.IsEmpty
+            ? filter.CheckFilter(testCases)
+            : testCases;
+
+        // Send filtered cases to sink
+        int cases = 0;
+        foreach (var testCase in filteredCases)
+        {
+            discoverySink.SendTestCase(testCase);
+            cases++;
         }
 
         return cases;

--- a/src/NUnitTestAdapter/VsTestFilter.cs
+++ b/src/NUnitTestAdapter/VsTestFilter.cs
@@ -214,9 +214,6 @@ public class VsTestFilterNonIde(IRunContext runContext) : VsTestFilter(runContex
     }
 }
 
-
-
-
 public class NTraitNameComparer : IEqualityComparer<NTrait>
 {
     public bool Equals(NTrait n, NTrait y)

--- a/src/NUnitTestAdapter/VsTestFilterForDiscovery.cs
+++ b/src/NUnitTestAdapter/VsTestFilterForDiscovery.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace NUnit.VisualStudio.TestAdapter;
+
+/// <summary>
+/// Filter for discovery scenarios (--list-tests with --filter).
+/// Uses reflection to access GetTestCaseFilter on IDiscoveryContext since
+/// the method exists on the concrete type but isn't exposed through the interface.
+/// </summary>
+public class VsTestFilterForDiscovery(IDiscoveryContext discoveryContext) : IVsTestFilter
+{
+    private static readonly List<string> SupportedProperties = ["FullyQualifiedName", "Name", "TestCategory", "Category", "Priority"];
+
+    private readonly ITestCaseFilterExpression _filterExpression = GetFilterExpressionViaReflection(discoveryContext);
+
+    public ITestCaseFilterExpression MsTestCaseFilterExpression => _filterExpression;
+
+    public bool IsEmpty => _filterExpression == null || string.IsNullOrEmpty(_filterExpression.TestCaseFilterValue);
+
+    public IEnumerable<TestCase> CheckFilter(IEnumerable<TestCase> tests)
+    {
+        return IsEmpty
+            ? tests
+            : tests.Where(t => _filterExpression.MatchTestCase(t, p => VsTestFilter.PropertyValueProvider(t, p))).ToList();
+    }
+
+    private static ITestCaseFilterExpression GetFilterExpressionViaReflection(IDiscoveryContext discoveryContext)
+    {
+        if (discoveryContext == null)
+            return null;
+
+        try
+        {
+            // IDiscoveryContext doesn't expose GetTestCaseFilter, but the concrete DiscoveryContext type has it.
+            // Use reflection to call it, similar to how MSTest and xUnit adapters handle this.
+            var method = discoveryContext.GetType().GetMethod(
+                "GetTestCaseFilter",
+                [typeof(IEnumerable<string>), typeof(Func<string, TestProperty>)]);
+
+            if (method == null)
+                return null;
+
+            var result = method.Invoke(discoveryContext, [SupportedProperties, (Func<string, TestProperty>)VsTestFilter.PropertyProvider]);
+            return result as ITestCaseFilterExpression;
+        }
+        catch
+        {
+            // If reflection fails, return null (no filtering)
+            return null;
+        }
+    }
+}

--- a/src/NUnitTestAdapter/VsTestFilterForDiscovery.cs
+++ b/src/NUnitTestAdapter/VsTestFilterForDiscovery.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -12,11 +13,11 @@ namespace NUnit.VisualStudio.TestAdapter;
 /// Uses reflection to access GetTestCaseFilter on IDiscoveryContext since
 /// the method exists on the concrete type but isn't exposed through the interface.
 /// </summary>
-public class VsTestFilterForDiscovery(IDiscoveryContext discoveryContext) : IVsTestFilter
+public class VsTestFilterForDiscovery(IDiscoveryContext discoveryContext, ITestLogger logger) : IVsTestFilter
 {
     private static readonly List<string> SupportedProperties = ["FullyQualifiedName", "Name", "TestCategory", "Category", "Priority"];
 
-    private readonly ITestCaseFilterExpression _filterExpression = GetFilterExpressionViaReflection(discoveryContext);
+    private readonly ITestCaseFilterExpression _filterExpression = GetFilterExpressionViaReflection(discoveryContext, logger);
 
     public ITestCaseFilterExpression MsTestCaseFilterExpression => _filterExpression;
 
@@ -29,7 +30,7 @@ public class VsTestFilterForDiscovery(IDiscoveryContext discoveryContext) : IVsT
             : tests.Where(t => _filterExpression.MatchTestCase(t, p => VsTestFilter.PropertyValueProvider(t, p))).ToList();
     }
 
-    private static ITestCaseFilterExpression GetFilterExpressionViaReflection(IDiscoveryContext discoveryContext)
+    private static ITestCaseFilterExpression GetFilterExpressionViaReflection(IDiscoveryContext discoveryContext, ITestLogger logger)
     {
         if (discoveryContext == null)
             return null;
@@ -43,14 +44,37 @@ public class VsTestFilterForDiscovery(IDiscoveryContext discoveryContext) : IVsT
                 [typeof(IEnumerable<string>), typeof(Func<string, TestProperty>)]);
 
             if (method == null)
+            {
+                logger?.Debug($"VsTestFilterForDiscovery: GetTestCaseFilter method not found on {discoveryContext.GetType().FullName}. Filter will be disabled.");
                 return null;
+            }
 
             var result = method.Invoke(discoveryContext, [SupportedProperties, (Func<string, TestProperty>)VsTestFilter.PropertyProvider]);
             return result as ITestCaseFilterExpression;
         }
-        catch
+        catch (AmbiguousMatchException ex)
         {
-            // If reflection fails, return null (no filtering)
+            logger?.Debug($"VsTestFilterForDiscovery: Ambiguous match for GetTestCaseFilter on {discoveryContext.GetType().FullName}. Filter will be disabled. {ex.Message}");
+            return null;
+        }
+        catch (TargetInvocationException ex)
+        {
+            logger?.Debug($"VsTestFilterForDiscovery: GetTestCaseFilter invocation failed on {discoveryContext.GetType().FullName}. Filter will be disabled. {ex.InnerException?.Message ?? ex.Message}");
+            return null;
+        }
+        catch (TargetParameterCountException ex)
+        {
+            logger?.Debug($"VsTestFilterForDiscovery: Parameter mismatch calling GetTestCaseFilter on {discoveryContext.GetType().FullName}. Filter will be disabled. {ex.Message}");
+            return null;
+        }
+        catch (MethodAccessException ex)
+        {
+            logger?.Debug($"VsTestFilterForDiscovery: Access denied calling GetTestCaseFilter on {discoveryContext.GetType().FullName}. Filter will be disabled. {ex.Message}");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            logger?.Warning($"VsTestFilterForDiscovery: Unexpected exception getting filter expression from {discoveryContext.GetType().FullName}. Filter will be disabled. {ex.ToString()}");
             return null;
         }
     }

--- a/src/NUnitTestAdapterTests/Fakes/FakeDiscoveryContextWithFilter.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeDiscoveryContextWithFilter.cs
@@ -1,0 +1,50 @@
+// ***********************************************************************
+// Copyright (c) 2026 Charlie Poole, Terje Sandstrom
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes;
+
+/// <summary>
+/// A fake discovery context that exposes a GetTestCaseFilter method so that
+/// <see cref="VsTestFilterForDiscovery"/> can find it via reflection (mimicking
+/// the real DiscoveryContext used in --list-tests --filter scenarios).
+/// </summary>
+class FakeDiscoveryContextWithFilter(IRunSettings runSettings, ITestCaseFilterExpression filterExpression) : IDiscoveryContext
+{
+    public IRunSettings RunSettings { get; } = runSettings;
+
+    // This method is intentionally public so that VsTestFilterForDiscovery can
+    // discover it via reflection (IDiscoveryContext doesn't declare it, but the
+    // concrete runtime type does).
+    public ITestCaseFilterExpression GetTestCaseFilter(
+        IEnumerable<string> supportedProperties,
+        Func<string, TestProperty> propertyProvider)
+    {
+        return filterExpression;
+    }
+}

--- a/src/NUnitTestAdapterTests/Fakes/FakeDiscoveryContextWithFilter.cs
+++ b/src/NUnitTestAdapterTests/Fakes/FakeDiscoveryContextWithFilter.cs
@@ -31,7 +31,7 @@ namespace NUnit.VisualStudio.TestAdapter.Tests.Fakes;
 
 /// <summary>
 /// A fake discovery context that exposes a GetTestCaseFilter method so that
-/// <see cref="VsTestFilterForDiscovery"/> can find it via reflection (mimicking
+/// <see cref="NUnit.VisualStudio.TestAdapter.VsTestFilterForDiscovery"/> can find it via reflection (mimicking
 /// the real DiscoveryContext used in --list-tests --filter scenarios).
 /// </summary>
 class FakeDiscoveryContextWithFilter(IRunSettings runSettings, ITestCaseFilterExpression filterExpression) : IDiscoveryContext

--- a/src/NUnitTestAdapterTests/NUnit3TestDiscovererTests.cs
+++ b/src/NUnitTestAdapterTests/NUnit3TestDiscovererTests.cs
@@ -22,13 +22,18 @@
 // ***********************************************************************
 
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 using NSubstitute;
 
 using NUnit.Framework;
+using NUnit.VisualStudio.TestAdapter.Tests.Fakes;
+using NUnit.VisualStudio.TestAdapter.Tests.Filtering;
 
 namespace NUnit.VisualStudio.TestAdapter.Tests;
 
@@ -51,5 +56,70 @@ public class NUnit3TestDiscovererTests
         var dc = Substitute.For<IDiscoveryContext>();
         sut.DiscoverTests([], dc, null, null);
         Assert.That(sut.NUnitEngineAdapter, Is.Not.Null);
+    }
+}
+
+/// <summary>
+/// Tests that verify DiscoverTests respects a filter supplied through IDiscoveryContext
+/// (the --list-tests --filter scenario, related to issues #438, #1227, #1426).
+/// </summary>
+[TestFixture]
+[Category("TestDiscovery")]
+public class DiscoveryFilterTests : ITestCaseDiscoverySink
+{
+    static readonly string MockAssemblyPath =
+        Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
+
+    private readonly List<TestCase> _testCases = [];
+
+    void ITestCaseDiscoverySink.SendTestCase(TestCase discoveredTest)
+    {
+        _testCases.Add(discoveredTest);
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        _testCases.Clear();
+    }
+
+    [Test]
+    public void DiscoverTests_WithCategoryFilter_OnlyReturnsMatchingTests()
+    {
+        var filterExpression = TestDoubleFilterExpression.AnyIsEqualTo("Category", "MockCategory");
+        var context = new FakeDiscoveryContextWithFilter(new FakeRunSettings(), filterExpression);
+
+        TestAdapterUtils.CreateDiscoverer().DiscoverTests(
+            [MockAssemblyPath], context, new MessageLoggerStub(), this);
+
+        Assert.That(_testCases.Count, Is.EqualTo(NUnit.Tests.Assemblies.MockTestFixture.MockCategoryTests));
+        var displayNames = _testCases.Select(tc => tc.DisplayName);
+        Assert.That(
+            displayNames,
+            Is.EquivalentTo(new[] { "MockTest2", "MockTest3" }),
+            "Only the two MockCategory tests should be discovered");
+    }
+
+    [Test]
+    public void DiscoverTests_WithNonMatchingCategoryFilter_ReturnsNoTests()
+    {
+        var filterExpression = TestDoubleFilterExpression.AnyIsEqualTo("Category", "CategoryThatMatchesNothing");
+        var context = new FakeDiscoveryContextWithFilter(new FakeRunSettings(), filterExpression);
+
+        TestAdapterUtils.CreateDiscoverer().DiscoverTests(
+            [MockAssemblyPath], context, new MessageLoggerStub(), this);
+
+        Assert.That(_testCases, Is.Empty);
+    }
+
+    [Test]
+    public void DiscoverTests_WithNoFilter_ReturnsAllTests()
+    {
+        var context = new FakeDiscoveryContext(new FakeRunSettings());
+
+        TestAdapterUtils.CreateDiscoverer().DiscoverTests(
+            [MockAssemblyPath], context, new MessageLoggerStub(), this);
+
+        Assert.That(_testCases.Count, Is.EqualTo(NUnit.Tests.Assemblies.MockAssembly.Tests));
     }
 }

--- a/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
+++ b/src/NUnitTestAdapterTests/TestDiscoveryTests.cs
@@ -167,7 +167,7 @@ public class FailuresInDiscovery : ITestCaseDiscoverySink
         var context = new FakeDiscoveryContext(null);
         var messageLoggerStub = new MessageLoggerStub();
         TestAdapterUtils.CreateDiscoverer().DiscoverTests(
-                new[] { "FileThatDoesntExist.dll" },
+                ["FileThatDoesntExist.dll"],
                 context,
                 messageLoggerStub,
                 this);


### PR DESCRIPTION

Fixes #438 
Fixes #1227 
Fixes #1426 

Adding capability to filter tests on discovery.
This works only for the --list-tests functionality.