### PR TITLE
MTP: stop advertising vstestProvider so the IDE consumes public properties

### DIFF
--- a/src/NUnitTestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+++ b/src/NUnitTestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 
-using Microsoft.Testing.Extensions.VSTestBridge.Capabilities;
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Extensions.VSTestBridge.Helpers;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
@@ -11,6 +11,33 @@ namespace NUnit.VisualStudio.TestAdapter.TestingPlatformAdapter
 {
     public static class TestApplicationBuilderExtensions
     {
+        // We intentionally do NOT use VSTestBridgeExtensionBaseCapabilities because that type also implements
+        // INamedFeatureCapability and advertises the "vstestProvider" capability. When a server (this adapter)
+        // advertises vstestProvider, Visual Studio Test Explorer consumes the legacy "vstest.TestCase.*"
+        // properties (serialized through Microsoft.Testing.Platform's internal SerializableKeyValuePairStringProperty
+        // key/value bag) instead of the public, structured properties.
+        //
+        // NUnitBridgedTestFramework.AddAdditionalProperties already emits the public TestMethodIdentifierProperty
+        // (serialized as location.type / location.method / location.method-arity), and location.file /
+        // location.line-start are emitted by the bridge from the TestCase. By not advertising vstestProvider we let
+        // the IDE consume those public properties and we stop depending on the internal key/value-pair shape.
+        //
+        // This mirrors what MSTest does with its own MSTestCapabilities type:
+        // https://github.com/microsoft/testfx/blob/main/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+        // MSTest can implement the internal IInternalVSTestBridgeTrxReportCapability (it is on the bridge's
+        // InternalsVisibleTo list); external adapters cannot, so we implement the public ITrxReportCapability here.
+        private sealed class NUnitTestFrameworkCapabilities : ITrxReportCapability
+        {
+            // Returning true advertises that NUnit can enrich nodes with the trx-report properties; the platform's
+            // TrxDataConsumer checks IsSupported and then calls Enable() only when a trx report was requested.
+            bool ITrxReportCapability.IsSupported => true;
+
+            void ITrxReportCapability.Enable()
+            {
+                // No-op: NUnitBridgedTestFramework always populates the trx-report properties for discovered/run nodes.
+            }
+        }
+
         public static void AddNUnit(this ITestApplicationBuilder testApplicationBuilder, Func<IEnumerable<Assembly>> getTestAssemblies)
         {
             NUnitExtension extension = new();
@@ -21,7 +48,7 @@ namespace NUnit.VisualStudio.TestAdapter.TestingPlatformAdapter
             testApplicationBuilder.AddRunSettingsEnvironmentVariableProvider(extension);
 
             testApplicationBuilder.RegisterTestFramework(
-                _ => new TestFrameworkCapabilities(new VSTestBridgeExtensionBaseCapabilities()),
+                _ => new TestFrameworkCapabilities(new NUnitTestFrameworkCapabilities()),
                 (capabilities, serviceProvider) => new NUnitBridgedTestFramework(extension, getTestAssemblies, serviceProvider, capabilities));
         }
     }


### PR DESCRIPTION
> ⚠️ **Draft / proposal** for discussion — see #1455 for the full background.

## What

Stop advertising the Microsoft.Testing.Platform `vstestProvider` capability from the NUnit adapter, so Visual Studio Test Explorer consumes the **public** structured node properties instead of the legacy `vstest.TestCase.*` key/value-pair properties.

## Why

When the adapter advertises `vstestProvider`, VS routes NUnit through its legacy parser that reads `vstest.TestCase.*` properties, which are serialized via Microsoft.Testing.Platform's **internal** `SerializableKeyValuePairStringProperty` key/value bag. The testfx team is deprecating that internal type in favor of public property types.

The good news: this adapter **already emits the public `TestMethodIdentifierProperty`** in `NUnitBridgedTestFramework.AddAdditionalProperties` (serialized as `location.type` / `location.method` / `location.method-arity`), and `location.file` / `location.line-start` come from the bridge. So the only thing still pinning VS to the legacy path is the `vstestProvider` capability advertised by `VSTestBridgeExtensionBaseCapabilities`.

## How

Replace `VSTestBridgeExtensionBaseCapabilities` (which implements both `IInternalVSTestBridgeTrxReportCapability` **and** `INamedFeatureCapability("vstestProvider")`) with a small capability that implements only the public `ITrxReportCapability`. This mirrors MSTest's [`MSTestCapabilities`](https://github.com/microsoft/testfx/blob/main/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs#L21-L31), which already dropped `vstestProvider`.

(MSTest implements the *internal* `IInternalVSTestBridgeTrxReportCapability` because `MSTest.TestAdapter` is on the bridge's `InternalsVisibleTo` list. External adapters can't, so this uses the public `ITrxReportCapability`. Note: the platform's `TrxDataConsumer` checks `IsSupported` then calls `Enable()`, so trx enrichment is effectively always-on with the public interface; the trx-only node properties are ignored by the server-mode (IDE) serializer, so there is no wire-format impact.)

## Notes / things to validate before this leaves draft

- **Sequencing:** the VS Test Explorer side must be able to recover everything from the public properties before this ships, otherwise NUnit navigation/grouping could regress. The non-`vstestProvider` path in VS already reconstructs the FQN from `location.type`/`location.method`, but please coordinate timing.
- **Parameterized tests:** VSTest's FQN encodes argument *values* (`Ns.Cls.Method(x: 1)`) which `TestMethodIdentifierProperty` (method name + arity, no values) can't represent. Per-row uniqueness should rely on the public `TestNode.Uid` (already unique per case). Worth a focused test pass on `TestCaseSource` / fixture-parameterized cases.
- **TRX reports:** `--report-trx` still works because the capability reports `IsSupported = true`.

Builds clean for `net462` + `net8.0`.

Refs #1455



---

### Additional consideration: `vstest.original-executor-uri` / framework identity

Dropping `vstestProvider` also stops the testfx bridge from emitting `vstest.original-executor-uri` (it is only sent from `CopyVSTestProviderProperties`, which runs under `vstestProvider`). In VS that property feeds:

- FQN-normalization kind — now moot, because this adapter emits managed names so the declaring-syntax kind is `ManagedMethod` on both parser paths.
- **Framework identity** (the `TestFramework` enum behind "Associate to Test Case"), which keys off the originating adapter URI.

**Parity note:** the bridge already only emits `original-executor-uri` under `vstestProvider`, so **MSTest — which already dropped `vstestProvider` — does not send it on the public path either.** This change therefore brings this adapter to exact parity with MSTest-via-MTP. If framework-identity features still work for MSTest under MTP they will work here too; if they depend on `original-executor-uri`, that is a **pre-existing gap shared with MSTest** and should be solved in testfx with a *public* framework/adapter-identity property — not in this adapter.

Everything required for navigation / grouping / source mapping is covered by public properties: `location.type` / `location.method` (this PR) and `location.file` / `location.line-start` (emitted unconditionally by the bridge).



---

### ⚠️ Correction / important caveat: parameterized-method identity is NOT free

An earlier framing of this change suggested dropping `vstestProvider` is essentially free once `TestMethodIdentifierProperty` is emitted. That is **not accurate**, and reviewers should weigh this:

- `TestMethodIdentifierProperty` / `location.method` carries the method name + parameter **types**, not the argument **values**.
- **Parameterized fixtures** (`TestFixture(...)`) encode their args in the *type* name (`Tests(One)`), which the builder preserves — these survive on the public path (this is what #1351 fixed).
- **Parameterized methods** (`[TestCase]` / `TestCaseSource`) encode their args in the FQN (`Tests.Test1(1)`). On the public path `location.method` becomes `Test1(System.Int32)` — **identical for every data row** — so all rows reconstruct to a single FQN and are distinguished only by the public `TestNode.Uid` + `DisplayName`.

Today, under `vstestProvider`, VS receives the per-row `vstest.TestCase.FullyQualifiedName` (`Tests.Test1(1)`). Dropping `vstestProvider` **collapses** that per-row FQN. Navigation and display still work via `Uid`/`DisplayName`, but the per-row **FQN hash** used by Azure DevOps "Associate to Test Case" would no longer be unique per row.

**Implication:** this migration should be sequenced with the VS Test Explorer side keying per-row identity off the public `Uid` (or a public property carrying the full parameterized name) before `vstestProvider` is fully dropped, otherwise method-parameterized tests regress. (Note: `TestMethodIdentifierProperty` here was originally added for the TRX class-name fix in #1351/#1449, independently of this capability change.)
