### PR TITLE
Updating VSTestBridge from version 2.2.3 to version 2.3.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,11 @@
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.3.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.1" />
+    <!-- Source-only package providing VSTest's filter-expression types (FilterExpressionWrapper /
+         TestCaseFilterExpression), compiled directly into the test assembly. This is the same package the
+         VSTestBridge uses internally, so the tests build the filter expression exactly as the product
+         does. Only available on the dnceng test-tools feed (see nuget.config). -->
+    <PackageVersion Include="Microsoft.TestPlatform.Filter.Source" Version="18.8.0-release-26277-01" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,8 +16,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.2.3" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.3.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>

--- a/nuget.config
+++ b/nuget.config
@@ -3,5 +3,9 @@
   <packageSources>
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <!-- VSTest source-only packages (e.g. Microsoft.TestPlatform.Filter.Source) are published to this
+         public dnceng feed rather than nuget.org. It is the same feed the
+         Microsoft.Testing.Extensions.VSTestBridge package consumes the filter sources from. -->
+    <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -27,12 +27,12 @@
 
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="2.2.3" />
-        <dependency id="Microsoft.Testing.Platform.MSBuild" version="2.2.3" />
+        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.1" />
+        <dependency id="Microsoft.Testing.Platform.MSBuild" version="2.3.1" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="2.2.3" />
-        <dependency id="Microsoft.Testing.Platform.MSBuild" version="2.2.3" />
+        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.1" />
+        <dependency id="Microsoft.Testing.Platform.MSBuild" version="2.3.1" />
         <dependency id="Microsoft.Extensions.DependencyModel" version="8.0.2" />
       </group>
 

--- a/src/NUnitTestAdapterTests/Filtering/FilteringTestUtils.cs
+++ b/src/NUnitTestAdapterTests/Filtering/FilteringTestUtils.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using NSubstitute;
@@ -36,18 +36,30 @@ public static class FilteringTestUtils
 {
     public static ITestCaseFilterExpression CreateVSTestFilterExpression(string filter)
     {
-        // Use reflection to create the FilterExpressionWrapper and TestCaseFilterExpression because
-        // they are internal types in a different assembly.
-        var filterExpressionWrapperType = Type.GetType("Microsoft.Testing.Extensions.VSTestBridge.ObjectModel.FilterExpressionWrapper, Microsoft.Testing.Extensions.VSTestBridge", throwOnError: true);
+        // FilterExpressionWrapper and TestCaseFilterExpression come from the source-only
+        // Microsoft.TestPlatform.Filter.Source package (compiled into this test assembly). This is the
+        // same package Microsoft.Testing.Extensions.VSTestBridge uses to parse filters, so the tests build
+        // the filter expression exactly as the product does.
+        //
+        // Outside the vstest repo that package compiles TestCaseFilterExpression as an internal type whose
+        // MatchTestCase takes only the property value provider and which does NOT implement the public
+        // ITestCaseFilterExpression. So we wrap it here, mirroring the adapter the bridge itself uses
+        // (VSTestBridge's BridgeFilterExpression / MSTest's MSTestFilterExpression).
+        var testCaseFilterExpression = new TestCaseFilterExpression(new FilterExpressionWrapper(filter));
+        return new BridgeFilterExpression(testCaseFilterExpression);
+    }
 
-        var filterExpressionWrapper =
-            filterExpressionWrapperType.GetTypeInfo()
-                .GetConstructor([typeof(string)])
-                .Invoke([filter]);
+    private sealed class BridgeFilterExpression : ITestCaseFilterExpression
+    {
+        private readonly TestCaseFilterExpression _testCaseFilterExpression;
 
-        return (ITestCaseFilterExpression)Type.GetType("Microsoft.Testing.Extensions.VSTestBridge.ObjectModel.TestCaseFilterExpression, Microsoft.Testing.Extensions.VSTestBridge", throwOnError: true).GetTypeInfo()
-            .GetConstructor([filterExpressionWrapperType])
-            .Invoke([filterExpressionWrapper]);
+        public BridgeFilterExpression(TestCaseFilterExpression testCaseFilterExpression)
+            => _testCaseFilterExpression = testCaseFilterExpression;
+
+        public string TestCaseFilterValue => _testCaseFilterExpression.TestCaseFilterValue;
+
+        public bool MatchTestCase(TestCase testCase, Func<string, object> propertyValueProvider)
+            => _testCaseFilterExpression.MatchTestCase(propertyValueProvider);
     }
 
     public static VsTestFilter CreateTestFilter(ITestCaseFilterExpression filterExpression)

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -9,6 +9,10 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <LangVersion>latest</LangVersion>
+    <!-- Microsoft.TestPlatform.Filter.Source compiles VSTest's filter types into this assembly. On net8.0
+         the same types are also present in the referenced Microsoft.VisualStudio.TestPlatform.Common
+         binary, which raises CS0436 (the source-compiled copy is the one used, which is what we want). -->
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
   </PropertyGroup>
 
     <PropertyGroup>
@@ -19,6 +23,7 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="TestCentric.Metadata" />
+    <PackageReference Include="Microsoft.TestPlatform.Filter.Source" PrivateAssets="all" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
   </ItemGroup>


### PR DESCRIPTION
Tests are failing


@Evangelink Can you have a look here?   Seems this is a breaking change from 2.2.3 to 2.3.1.

This bridge version (2.3.1) fails on loading Microsoft.Testing.Extensions.VSTestBridge.ObjectModel.FilterExpressionWrapper  from Microsoft.Testing.Extensions.VSTestBridge

<img width="2808" height="776" alt="image" src="https://github.com/user-attachments/assets/eef3402e-8938-4aaf-8b4f-2738a738c43d" />


