### PR TITLE
Fix filtering tests for VSTestBridge 2.3.x using the source filter package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,11 @@
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.3.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.1" />
+    <!-- Source-only package providing VSTest's filter-expression types (FilterExpressionWrapper /
+         TestCaseFilterExpression), compiled directly into the test assembly. This is the same package the
+         VSTestBridge uses internally, so the tests build the filter expression exactly as the product
+         does. Only available on the dnceng test-tools feed (see nuget.config). -->
+    <PackageVersion Include="Microsoft.TestPlatform.Filter.Source" Version="18.8.0-release-26277-01" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>

--- a/nuget.config
+++ b/nuget.config
@@ -3,5 +3,9 @@
   <packageSources>
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <!-- VSTest source-only packages (e.g. Microsoft.TestPlatform.Filter.Source) are published to this
+         public dnceng feed rather than nuget.org. It is the same feed the
+         Microsoft.Testing.Extensions.VSTestBridge package consumes the filter sources from. -->
+    <add key="test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NUnitTestAdapterTests/Filtering/FilteringTestUtils.cs
+++ b/src/NUnitTestAdapterTests/Filtering/FilteringTestUtils.cs
@@ -24,7 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using NSubstitute;
@@ -36,18 +36,30 @@ public static class FilteringTestUtils
 {
     public static ITestCaseFilterExpression CreateVSTestFilterExpression(string filter)
     {
-        // Use reflection to create the FilterExpressionWrapper and TestCaseFilterExpression because
-        // they are internal types in a different assembly.
-        var filterExpressionWrapperType = Type.GetType("Microsoft.Testing.Extensions.VSTestBridge.ObjectModel.FilterExpressionWrapper, Microsoft.Testing.Extensions.VSTestBridge", throwOnError: true);
+        // FilterExpressionWrapper and TestCaseFilterExpression come from the source-only
+        // Microsoft.TestPlatform.Filter.Source package (compiled into this test assembly). This is the
+        // same package Microsoft.Testing.Extensions.VSTestBridge uses to parse filters, so the tests build
+        // the filter expression exactly as the product does.
+        //
+        // Outside the vstest repo that package compiles TestCaseFilterExpression as an internal type whose
+        // MatchTestCase takes only the property value provider and which does NOT implement the public
+        // ITestCaseFilterExpression. So we wrap it here, mirroring the adapter the bridge itself uses
+        // (VSTestBridge's BridgeFilterExpression / MSTest's MSTestFilterExpression).
+        var testCaseFilterExpression = new TestCaseFilterExpression(new FilterExpressionWrapper(filter));
+        return new BridgeFilterExpression(testCaseFilterExpression);
+    }
 
-        var filterExpressionWrapper =
-            filterExpressionWrapperType.GetTypeInfo()
-                .GetConstructor([typeof(string)])
-                .Invoke([filter]);
+    private sealed class BridgeFilterExpression : ITestCaseFilterExpression
+    {
+        private readonly TestCaseFilterExpression _testCaseFilterExpression;
 
-        return (ITestCaseFilterExpression)Type.GetType("Microsoft.Testing.Extensions.VSTestBridge.ObjectModel.TestCaseFilterExpression, Microsoft.Testing.Extensions.VSTestBridge", throwOnError: true).GetTypeInfo()
-            .GetConstructor([filterExpressionWrapperType])
-            .Invoke([filterExpressionWrapper]);
+        public BridgeFilterExpression(TestCaseFilterExpression testCaseFilterExpression)
+            => _testCaseFilterExpression = testCaseFilterExpression;
+
+        public string TestCaseFilterValue => _testCaseFilterExpression.TestCaseFilterValue;
+
+        public bool MatchTestCase(TestCase testCase, Func<string, object> propertyValueProvider)
+            => _testCaseFilterExpression.MatchTestCase(propertyValueProvider);
     }
 
     public static VsTestFilter CreateTestFilter(ITestCaseFilterExpression filterExpression)

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -9,6 +9,10 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <LangVersion>latest</LangVersion>
+    <!-- Microsoft.TestPlatform.Filter.Source compiles VSTest's filter types into this assembly. On net8.0
+         the same types are also present in the referenced Microsoft.VisualStudio.TestPlatform.Common
+         binary, which raises CS0436 (the source-compiled copy is the one used, which is what we want). -->
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
   </PropertyGroup>
 
     <PropertyGroup>
@@ -19,6 +23,7 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="TestCentric.Metadata" />
+    <PackageReference Include="Microsoft.TestPlatform.Filter.Source" PrivateAssets="all" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
   </ItemGroup>


### PR DESCRIPTION
Fixes the failing tests in #1466 (the VSTestBridge 2.2.3 -> 2.3.1 bump). Targets that PR's `minornugetupdate` branch so it can be merged straight in.

### Root cause
This is **not** a breaking change to any public `Microsoft.Testing.Extensions.VSTestBridge` API, and the shipped adapter is unaffected. The failure was entirely in the test helper `FilteringTestUtils.CreateVSTestFilterExpression`, which reached into **internal** bridge types by fully-qualified name via reflection and cast the result to `ITestCaseFilterExpression`.

In bridge **2.3.0** the bridge switched to the source-only `Microsoft.TestPlatform.Filter.Source` package, which changed those internal types in two ways:

1. **Namespace moved** `Microsoft.Testing.Extensions.VSTestBridge.ObjectModel` -> `Microsoft.VisualStudio.TestPlatform.Common.Filtering`, so the old `Type.GetType(..., throwOnError: true)` threw `TypeLoadException` (the error in the screenshot on #1466).
2. **Interface dropped** the new `TestCaseFilterExpression` no longer implements the public `ITestCaseFilterExpression` (the bridge wraps it internally), so even after fixing the namespace the cast threw `InvalidCastException`.

Both types were always `internal`, so nothing in the supported surface broke.

### Fix
Instead of reflecting into bridge internals, reference the **same source-only `Microsoft.TestPlatform.Filter.Source` package the bridge uses** and build the filter expression directly, then wrap it in a small `ITestCaseFilterExpression` adapter - mirroring the bridge's own `BridgeFilterExpression` (and MSTest's `MSTestFilterExpression`). No more reflection.

Changes:
- Add the dnceng public **test-tools** feed to `nuget.config` (this source package isn't published to nuget.org) and pin it in `Directory.Packages.props`.
- Reference the package (`PrivateAssets=all`) from the test project.
- Rewrite `FilteringTestUtils` to construct `new TestCaseFilterExpression(new FilterExpressionWrapper(filter))` and wrap it.
- Suppress `CS0436` on `net8.0`, where the source-compiled types also exist in the referenced `Microsoft.VisualStudio.TestPlatform.Common` binary; the source-compiled copy is the one used.

### Verified
`dotnet test -c Release --filter FullyQualifiedName~Filtering` -> **43 passed, 0 failed on both net462 and net8.0** (was 5 failed before). Full Release build is clean (warnings-as-errors on).