### PR TITLE
Removing TestCentric.Metadata reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,6 @@
     <PackageVersion Include="nunit.engine" Version="3.22.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageVersion Include="SourceLink.Create.CommandLine" Version="2.8.3" />
-    <PackageVersion Include="TestCentric.Metadata" Version="3.0.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
+++ b/src/NUnitTestAdapter/NUnit.TestAdapter.csproj
@@ -38,7 +38,6 @@
         <PackageReference Include="Microsoft.Testing.Extensions.VSTestBridge" />
         <PackageReference Include="SourceLink.Create.CommandLine" PrivateAssets="All" />
         <PackageReference Include="nunit.engine" />
-        <PackageReference Include="TestCentric.Metadata" Aliases="TestCentric" />
     </ItemGroup>
 
     <Target Name="PreventTestPlatformObjectModelCopyLocal" AfterTargets="ResolveReferences">

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.Testing.Extensions.VSTestBridge" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="TestCentric.Metadata" />
     <PackageReference Include="Microsoft.TestPlatform.Filter.Source" PrivateAssets="all" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
 

--- a/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
+++ b/src/NUnitTestAdapterTests/NUnit.TestAdapter.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.TestPlatform.Filter.Source" PrivateAssets="all" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
   </ItemGroup>
 

--- a/src/NUnitTestAdapterTests/NuspecDependenciesTests.cs
+++ b/src/NUnitTestAdapterTests/NuspecDependenciesTests.cs
@@ -29,7 +29,6 @@ namespace NUnit.VisualStudio.TestAdapter.Tests
         [
             "SourceLink.Create.CommandLine",  // Only used as a development dependency in the adapter, so is only in csproj
             "nunit.engine",  // Is to be embedded - 3 files, so don't need to be in dependency list in nuspec, but must be in file list
-            "TestCentric.Metadata",  // Only one file is embedded in the package, is in the file list
             "Microsoft.Testing.Platform.MSBuild",  // Must be in dependency list in nuspec, but don't need to be a package reference in csproj
             "Microsoft.Extensions.DependencyModel"  // Must be in dependency list in nuspec for version resolution (required by nunit.engine for net8.0), but don't need to be a package reference in csproj
         ];


### PR DESCRIPTION
TestCentric.Metadata is added as a reference to this project but does not seem to be used anywhere in the solution. Further, it is not included in the .cake, .nuspec or .props files, so it is not deployed to consumers, either.

It seems to have been added to replace 'Mono.Cecil' at some point, but the change was not completed. I'm not entirely sure. I have pasted an AI produced git history timeline below in an attempt to work out why it was added as a reference at all - perhaps you can make more sense of it.

This was a problem in my own project as one of my unit tests would walk dependancy references to verify they were deployed. TestCentric.Metadata was a transitive dependancy of NUnit3TestAdapter that was missing.

I note also that https://github.com/nunit/nunit3-vs-adapter/issues/1314 has listed TestCentric.Metadata as likely abandoned.

# AI-Generated Discussion and Timeline

## Remove the unused `TestCentric.Metadata` package reference

The adapter carries a `PackageReference` to `TestCentric.Metadata` that no code has ever used. The history shows it was always a packaging vehicle, never an API dependency — and the thing it was a vehicle for moved into `nunit.engine` years ago.

### How it got here

| Date | Commit | |
|---|---|---|
| 2021-04-04 | `1f7ff395` | "Added alias" — `TestCentric.Metadata` 1.4.1 added with `Aliases="TestCentric"` |
| 2021-04-05 | `a2ad807a` | "removing mono.cecil" — `EmbeddedAssemblyResolution.cs` wrapped in `#if ENABLED`, embedding target commented out |
| 2023-09-26 | `0a7ac088` | "Updated engine to 3.15.5, **which has TestCentric.Metdata 2.0.0 included**" — bumped 1.7.1 → 2.0.0 to match the engine |
| 2024-04-10 | `f9b355ac` | "Updates packages (#1164)" — bumped 2.0.0 → 3.0.2 |

The alias was added one day before the Mono.Cecil embedding was disabled, so it replaced an embedding mechanism rather than any API use. `EmbeddedAssemblyResolution.cs` is still in the tree, still behind `#if ENABLED`, and its allow-list names only `"Mono.Cecil"`.

`0a7ac088` shows the reference's only real purpose: keeping its version in lockstep with what `nunit.engine` bundles. That is a packaging concern.

`f9b355ac` is where it came apart. `TestCentric.Metadata` renamed its own output assembly between 2.0.0 and 3.0.2 — `testcentric.engine.metadata.dll` became `TestCentric.Metadata.dll` — and that bulk update crossed the rename without touching `build.cake`, the `.props` files, or the `.nuspec`. Nothing looked wrong, because a file named `testcentric.engine.metadata.dll` kept appearing in the build output the whole time, supplied by `nunit.engine` at a different assembly version.

### It was never used

Every `.cs` blob that has ever existed in the repo — 2,744 blobs, 1,776 commits, all branches and tags back to 2011:

- `TestCentric` appears in one file, `NuspecDependenciesTests.cs`, only as a package-name string.
- `extern alias TestCentric`, `TestCentric::`, `using TestCentric` — zero occurrences, ever.

The compiled adapter agrees: `ref TestCentric.Metadata v3.0.4.0  typerefs=0  forwarders=0`, on both target frameworks. The reference exists only because `Aliases=` makes Roslyn emit one; with no type references the CLR never loads it.


----