### PR TITLE
Fix tokenizer: allow whitespace before '(' and guard unbalanced parens

### DIFF
--- a/src/NUnitTestAdapter/TestFilterConverter/Tokenizer.cs
+++ b/src/NUnitTestAdapter/TestFilterConverter/Tokenizer.cs
@@ -234,9 +234,18 @@ public class Tokenizer
 
         CollectWordChars(sb);
 
-        if (NextChar != '(')
-            return new Token(TokenKind.Word, sb.ToString()) { Pos = pos };
+        int preWhitespaceIndex = index;
+        var whitespace = new StringBuilder();
+        while (char.IsWhiteSpace(NextChar))
+            whitespace.Append(GetChar());
 
+        if (NextChar != '(')
+        {
+            index = preWhitespaceIndex;
+            return new Token(TokenKind.Word, sb.ToString()) { Pos = pos };
+        }
+
+        sb.Append(whitespace);
         CollectBalancedParentheticalExpression(sb);
 
         while (NextChar == '+' || NextChar == '.')
@@ -272,7 +281,7 @@ public class Tokenizer
                 else if (c == '"')
                     CollectQuotedString(sb);
             }
-            while (depth > 0);
+            while (depth > 0 && NextChar != EOF_CHAR);
         }
     }
 
@@ -309,4 +318,3 @@ public class Tokenizer
             index++;
     }
 }
-

--- a/src/NUnitTestAdapterTests/TestFilterConverterTests/TestFilterParserTests.cs
+++ b/src/NUnitTestAdapterTests/TestFilterConverterTests/TestFilterParserTests.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Threading.Tasks;
 using System.Xml;
 using NUnit.Framework;
 using NUnit.VisualStudio.TestAdapter.TestFilterConverter;
@@ -88,6 +89,17 @@ public class TestFilterParserTests
     [TestCase(
         "FullyQualifiedName!~My.Test.Fixture.Method(42)",
         @"<not><test re='1'>My\.Test\.Fixture\.Method\(42\)</test></not>")]
+
+    // FQN - Whitespace between the method name and its argument list
+    [TestCase(
+        "FullyQualifiedName=My.Test.Fixture.Method (42)",
+        "<test>My.Test.Fixture.Method (42)</test>")]
+    [TestCase(
+        "FullyQualifiedName~My.Test.Fixture.Method (42)",
+        @"<test re='1'>My\.Test\.Fixture\.Method \(42\)</test>")]
+    [TestCase(
+        "FullyQualifiedName=My.Test.Fixture.Method  (Case 1)",
+        "<test>My.Test.Fixture.Method  (Case 1)</test>")]
 
     // FQN - String argument escaping
     [TestCase(
@@ -184,5 +196,16 @@ public class TestFilterParserTests
     public void TestParser_InvalidInput(string input, Type type)
     {
         Assert.That(() => _parser.Parse(input), Throws.TypeOf(type));
+    }
+
+    // Run off the test thread with a bounded wait: an unbalanced '(' must not hang the tokenizer forever.
+    [TestCase("FullyQualifiedName~My.Test.Fixture.Method(Case")]
+    [TestCase("FullyQualifiedName=My.Test.Fixture.Method(\"Case")]
+    public void TestParser_UnbalancedParenthesesDoesNotHang(string input)
+    {
+        var task = Task.Run(() => _parser.Parse(input));
+
+        Assert.That(task.Wait(TimeSpan.FromSeconds(2)), Is.True,
+            "Parse did not return - the tokenizer is likely stuck collecting an unbalanced '('.");
     }
 }


### PR DESCRIPTION
- GetWordOrFqn now peeks past whitespace between a name and its argument list instead of requiring '(' to immediately follow word characters, so names like "Method (Case 1)" tokenize as a single FQN instead of a Word followed by a stray FQN token.
- CollectBalancedParentheticalExpression now stops at EOF even when depth never reaches 0, preventing an infinite loop on a truncated filter with an unbalanced '('.
- Add regression tests for both: whitespace-before-'(' FQN parsing, and a bounded-timeout test proving unbalanced parens no longer hang.

Fixes #1490 