### PR TITLE
Update Microsoft.Testing.Extensions.VSTestBridge and TrxReport to 2.4.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,8 +16,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.3.3" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.4.0" />
     <!-- Source-only package providing VSTest's filter-expression types (FilterExpressionWrapper /
          TestCaseFilterExpression), compiled directly into the test assembly. This is the same package the
          VSTestBridge uses internally, so the tests build the filter expression exactly as the product

--- a/nuget/NUnit3TestAdapter.nuspec
+++ b/nuget/NUnit3TestAdapter.nuspec
@@ -27,12 +27,12 @@
 
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" />
-        <dependency id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" />
+        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="2.4.0" />
+        <dependency id="Microsoft.Testing.Platform.MSBuild" version="2.4.0" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="2.3.3" />
-        <dependency id="Microsoft.Testing.Platform.MSBuild" version="2.3.3" />
+        <dependency id="Microsoft.Testing.Extensions.VSTestBridge" version="2.4.0" />
+        <dependency id="Microsoft.Testing.Platform.MSBuild" version="2.4.0" />
         <dependency id="Microsoft.Extensions.DependencyModel" version="8.0.2" />
       </group>
 

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -568,7 +568,9 @@ public sealed class NUnit3TestExecutor : NUnitTestAdapter, ITestExecutor, IDispo
             if (!(enableShutdown &&
                   !runContext
                       .KeepAlive)) // Otherwise causes exception when run as commandline, illegal to enableshutdown when Keepalive is false, might be only VS2012
+#pragma warning disable CS0618 // Obsolete on newer hosts, but still respected by older VSTest hosts we support
                 frameworkHandle.EnableShutdownAfterTestRun = enableShutdown;
+#pragma warning restore CS0618
         }
 
         TestLog.Debug("EnableShutdown: " + enableShutdown);

--- a/src/NUnitTestAdapter/NUnit3TestExecutor.cs
+++ b/src/NUnitTestAdapter/NUnit3TestExecutor.cs
@@ -567,7 +567,7 @@ public sealed class NUnit3TestExecutor : NUnitTestAdapter, ITestExecutor, IDispo
         {
             if (!(enableShutdown &&
                   !runContext
-                      .KeepAlive)) // Otherwise causes exception when run as commandline, illegal to enableshutdown when Keepalive is false, might be only VS2012
+                      .KeepAlive)) // Otherwise causes exception when run from command line; illegal to enable shutdown when KeepAlive is false (might be only VS2012)
 #pragma warning disable CS0618 // Obsolete on newer hosts, but still respected by older VSTest hosts we support
                 frameworkHandle.EnableShutdownAfterTestRun = enableShutdown;
 #pragma warning restore CS0618


### PR DESCRIPTION
## Summary
- Bump `Microsoft.Testing.Extensions.VSTestBridge` and `Microsoft.Testing.Extensions.TrxReport` to 2.4.0 in `Directory.Packages.props`.
- Update `nuget/NUnit3TestAdapter.nuspec` dependencies to match (also bumps `Microsoft.Testing.Platform.MSBuild` to 2.4.0, matching VSTestBridge's `Microsoft.Testing.Platform` requirement).
- Suppress a new CS0618 (obsolete `IFrameworkHandle.EnableShutdownAfterTestRun`) that surfaced from the transitive `Microsoft.TestPlatform.ObjectModel` 18.9.0 bump, which broke the Release build (warnings-as-errors). Same pragma pattern already used in `CategoryList.cs`.

## Test plan
- [x] `dotnet restore`
- [x] `dotnet build -c Release` for adapter, unit test, and acceptance projects
- [x] `dotnet test` on `NUnit.TestAdapter.Tests.csproj` for both `net462` (404 passed) and `net8.0` (401 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxFXoJ3Z3TS3kRnwzR6x25